### PR TITLE
Load app plugins through entrypoint

### DIFF
--- a/src/ai/backend/gateway/config.py
+++ b/src/ai/backend/gateway/config.py
@@ -37,6 +37,9 @@ def load_config(argv=None, extra_args_funcs=()):
     parser.add('--db-password', env_var='BACKEND_DB_PASSWORD',
                type=str, default='develove',
                help='The password to authenticate to the database server.')
+    parser.add('--disable-plugins', env_var='BACKEND_DISABLE_PLUGINS',
+               type=str, default='',
+               help='A comma-separated blacklist of app plugins not to use.')
     for func in extra_args_funcs:
         func(parser)
     args = parser.parse_args(args=argv)

--- a/src/ai/backend/gateway/config.py
+++ b/src/ai/backend/gateway/config.py
@@ -37,10 +37,6 @@ def load_config(argv=None, extra_args_funcs=()):
     parser.add('--db-password', env_var='BACKEND_DB_PASSWORD',
                type=str, default='develove',
                help='The password to authenticate to the database server.')
-    parser.add('--extensions', env_var='BACKEND_EXTENSIONS',
-               type=str, default='',
-               help='A comma-separated list of extension module names installed '
-                    'as Python packages')
     for func in extra_args_funcs:
         func(parser)
     args = parser.parse_args(args=argv)

--- a/src/ai/backend/gateway/server.py
+++ b/src/ai/backend/gateway/server.py
@@ -334,7 +334,7 @@ async def server_main(loop, pidx, _args):
         subapp_mod = importlib.import_module(pkgname, 'ai.backend.gateway')
         init_subapp(getattr(subapp_mod, 'create_app'))
 
-    app_plugin_entry_prefix = 'backendai_app_v10'
+    app_plugin_entry_prefix = 'backendai_webapp_v10'
     if app['config'].disable_plugins:
         app['config'].disable_plugins = app['config'].disable_plugins.split(',')
     for entrypoint in pkg_resources.iter_entry_points(app_plugin_entry_prefix):

--- a/src/ai/backend/gateway/server.py
+++ b/src/ai/backend/gateway/server.py
@@ -8,6 +8,7 @@ import importlib
 from ipaddress import ip_address
 import logging
 import os
+import pkg_resources
 import ssl
 import sys
 import traceback
@@ -293,8 +294,6 @@ async def server_main(loop, pidx, _args):
         '.auth', '.ratelimit',
         '.vfolder', '.admin',
         '.kernel', '.stream',
-    ] + [
-        ext_name for ext_name in app['config'].extensions
     ]
 
     global_exception_handler = functools.partial(handle_loop_error, app)
@@ -306,11 +305,9 @@ async def server_main(loop, pidx, _args):
     loop.set_exception_handler(global_exception_handler)
     aiojobs.aiohttp.setup(app, **scheduler_opts)
     await gw_init(app)
-    for pkgname in subapp_pkgs:
-        if pidx == 0:
-            log.info('Loading module: %s', pkgname[1:])
-        subapp_mod = importlib.import_module(pkgname, 'ai.backend.gateway')
-        subapp, global_middlewares = getattr(subapp_mod, 'create_app')()
+
+    def init_subapp(create_subapp):
+        subapp, global_middlewares = create_subapp()
         assert isinstance(subapp, web.Application)
         # Allow subapp's access to the root app properties.
         # These are the public APIs exposed to extensions as well.
@@ -330,6 +327,19 @@ async def server_main(loop, pidx, _args):
                 legacy_path = f'/v{version}{subpath}'
                 handler = _get_legacy_handler(r.handler, subapp, version)
                 app.router.add_route(r.method, legacy_path, handler)
+
+    for pkgname in subapp_pkgs:
+        if pidx == 0:
+            log.info('Loading module: %s', pkgname[1:])
+        subapp_mod = importlib.import_module(pkgname, 'ai.backend.gateway')
+        init_subapp(getattr(subapp_mod, 'create_app'))
+
+    app_plugin_entry_prefix = 'backendai_app_v10'
+    for entrypoint in pkg_resources.iter_entry_points(app_plugin_entry_prefix):
+        if pidx == 0:
+            log.info(f'Loading app plugin: {entrypoint.module_name}')
+        plugin = entrypoint.load()
+        init_subapp(getattr(plugin, 'create_app'))
 
     app.on_shutdown.append(gw_shutdown)
     app.on_cleanup.append(gw_cleanup)

--- a/src/ai/backend/gateway/server.py
+++ b/src/ai/backend/gateway/server.py
@@ -335,7 +335,11 @@ async def server_main(loop, pidx, _args):
         init_subapp(getattr(subapp_mod, 'create_app'))
 
     app_plugin_entry_prefix = 'backendai_app_v10'
+    if app['config'].disable_plugins:
+        app['config'].disable_plugins = app['config'].disable_plugins.split(',')
     for entrypoint in pkg_resources.iter_entry_points(app_plugin_entry_prefix):
+        if entrypoint.name in app['config'].disable_plugins:
+            continue
         if pidx == 0:
             log.info(f'Loading app plugin: {entrypoint.module_name}')
         plugin = entrypoint.load()


### PR DESCRIPTION
Detect app plugins through entrypoint, not by scanning modules in `BACKEND_EXTENSIONS`.

Users can disable installed app plugins through `--disable-plugins` cli option.