### PR TITLE
User provided docker registry

### DIFF
--- a/src/ai/backend/gateway/config.py
+++ b/src/ai/backend/gateway/config.py
@@ -16,7 +16,7 @@ def load_config(argv=None, extra_args_funcs=()):
                default=HostPortPair(ip_address('127.0.0.1'), 2379),
                help='The host:port pair of the etcd cluster or its proxy.')
     parser.add('--docker-registry', env_var='BACKEND_DOCKER_REGISTRY',
-               type=str, metavar='URL', default=None,
+               type=str, metavar='URL', default='lablup',
                help='The host:port pair of the private docker registry '
                     'that caches the kernel images')
     parser.add('--agent-port', env_var='BACKEND_AGENT_PORT',

--- a/src/ai/backend/gateway/etcd.py
+++ b/src/ai/backend/gateway/etcd.py
@@ -33,8 +33,10 @@ class ConfigServer:
             instance_ip = await get_instance_ip()
         event_addr = f'{instance_ip}:{app_config.events_port}'
         await self.etcd.put_multi(
-            ['nodes/manager', 'nodes/redis', 'nodes/manager/event_addr'],
-            [instance_id, app_config.redis_addr, event_addr])
+            ['nodes/manager', 'nodes/redis',
+             'nodes/manager/event_addr', 'nodes/docker_registry'],
+            [instance_id, app_config.redis_addr,
+             event_addr, app_config.docker_registry])
 
     async def deregister_myself(self):
         await self.etcd.delete_prefix('nodes/manager')

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -214,6 +214,7 @@ async def app(event_loop, test_ns, test_db, unused_tcp_port):
     app['config'].redis_addr = host_port_pair(os.environ['BACKEND_REDIS_ADDR'])
     app['config'].db_addr = host_port_pair(os.environ['BACKEND_DB_ADDR'])
     app['config'].db_name = test_db
+    app['config'].docker_registry = 'lablup'
 
     # Override extra settings
     app['config'].namespace = test_ns

--- a/tests/gateway/test_config.py
+++ b/tests/gateway/test_config.py
@@ -43,7 +43,7 @@ def test_args_parse_by_load_config():
     assert args.namespace == namespace
     assert args.etcd_addr == host_port_pair(etcd_addr)
     assert args.events_port == port_no(events_port)
-    assert args.docker_registry is None
+    assert args.docker_registry == 'lablup'
     assert args.heartbeat_timeout == 5.0
     assert args.service_ip == ip_address('0.0.0.0')
     assert args.service_port == 0

--- a/tests/gateway/test_etcd.py
+++ b/tests/gateway/test_etcd.py
@@ -81,6 +81,7 @@ class TestConfigServer:
         assert await config_server.etcd.get('nodes/manager')
         assert await config_server.etcd.get('nodes/redis')
         assert await config_server.etcd.get('nodes/manager/event_addr')
+        assert (await config_server.etcd.get('nodes/docker_registry')) == 'lablup'
 
     @pytest.mark.asyncio
     async def test_deregister_myself(self, app, config_server):


### PR DESCRIPTION
Pull request for #43.

- Get custom docker registry by `--docker-registry` option when starting gateway server.
- Save it into etcd config server when init.
