### PR TITLE
Feature/#165 vfolder api for sent invitation

### DIFF
--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -944,6 +944,8 @@ async def list_shared_vfolders(request: web.Request) -> web.Response:
     '''
     dbpool = request.app['dbpool']
     access_key = request['keypair']['access_key']
+    params = await request.json() if request.can_read_body else request.query
+    target_vfid = params.get('vfolder_id', None)
     log.info('VFOLDER.LIST_SHARED_VFOLDERS (u:{0})', access_key)
     async with dbpool.acquire() as conn:
         j = (vfolder_permissions
@@ -954,6 +956,8 @@ async def list_shared_vfolders(request: web.Request) -> web.Response:
                             users.c.email])
                    .select_from(j)
                    .where((vfolders.c.user == request['user']['uuid'])))
+        if target_vfid is not None:
+            query = query.where(vfolders.c.id == target_vfid)
         result = await conn.execute(query)
         shared_list = await result.fetchall()
     shared_info = []

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -962,7 +962,10 @@ async def list_shared_vfolders(request: web.Request) -> web.Response:
             'vfolder_id': str(shared.id),
             'vfolder_name': str(shared.name),
             'shared_by': request['user']['email'],
-            'shared_to': shared.email,
+            'shared_to': {
+                'uuid': str(shared.user),
+                'email': shared.email,
+            },
             'perm': shared.permission.value,
         })
     resp = {'shared': shared_info}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -93,6 +93,13 @@ def prepare_and_cleanup_databases(request, test_ns, test_db,
                      'https://registry-1.docker.io'])
     subprocess.call(['python', '-m', 'ai.backend.manager.cli', 'etcd', 'put',
                      'config/redis/addr', '127.0.0.1:8110'])
+    # Add fake plugin settings.
+    subprocess.call(['python', '-m', 'ai.backend.manager.cli', 'etcd', 'put',
+                     'config/plugins/cloudia/base_url', '127.0.0.1:8090'])
+    subprocess.call(['python', '-m', 'ai.backend.manager.cli', 'etcd', 'put',
+                     'config/plugins/cloudia/user', 'fake-cloudia-user@lablup.com'])
+    subprocess.call(['python', '-m', 'ai.backend.manager.cli', 'etcd', 'put',
+                     'config/plugins/cloudia/password', 'fake-password'])
 
     def finalize_etcd():
         subprocess.call(['python', '-m', 'ai.backend.manager.cli', 'etcd', 'delete',

--- a/tests/gateway/test_vfolder.py
+++ b/tests/gateway/test_vfolder.py
@@ -1513,7 +1513,7 @@ class TestInvitation:
         assert uuid.UUID(rsp_json['shared'][0]['vfolder_id']).hex == folder_info['id']
         assert rsp_json['shared'][0]['vfolder_name'] == folder_info['name']
         assert rsp_json['shared'][0]['shared_by'] == 'admin@lablup.com'
-        assert rsp_json['shared'][0]['shared_to'] == 'user@lablup.com'
+        assert rsp_json['shared'][0]['shared_to']['email'] == 'user@lablup.com'
         assert rsp_json['shared'][0]['perm'] == 'rw'
 
     @pytest.mark.asyncio

--- a/tests/gateway/test_vfolder.py
+++ b/tests/gateway/test_vfolder.py
@@ -1516,6 +1516,29 @@ class TestInvitation:
         assert rsp_json['shared'][0]['shared_to']['email'] == 'user@lablup.com'
         assert rsp_json['shared'][0]['perm'] == 'rw'
 
+        # Request with target vfolder_id.
+        url = f'/v3/folders/_/shared'
+        req_bytes = json.dumps({'vfolder_id': folder_info['id']}).encode()
+        headers = get_headers('GET', url, req_bytes)
+        ret = await client.get(url, data=req_bytes, headers=headers)
+        rsp_json = await ret.json()
+
+        assert len(rsp_json['shared']) == 1
+        assert uuid.UUID(rsp_json['shared'][0]['vfolder_id']).hex == folder_info['id']
+        assert rsp_json['shared'][0]['vfolder_name'] == folder_info['name']
+        assert rsp_json['shared'][0]['shared_by'] == 'admin@lablup.com'
+        assert rsp_json['shared'][0]['shared_to']['email'] == 'user@lablup.com'
+        assert rsp_json['shared'][0]['perm'] == 'rw'
+
+        # Request with invalid target vfolder_id.
+        url = f'/v3/folders/_/shared'
+        req_bytes = json.dumps({'vfolder_id': str(uuid.uuid4())}).encode()
+        headers = get_headers('GET', url, req_bytes)
+        ret = await client.get(url, data=req_bytes, headers=headers)
+        rsp_json = await ret.json()
+
+        assert len(rsp_json['shared']) == 0
+
     @pytest.mark.asyncio
     async def test_update_shared_vfolder(self, prepare_vfolder, get_headers,
                                          folder_mount, folder_host, folder_fsprefix):

--- a/tests/model_factory.py
+++ b/tests/model_factory.py
@@ -142,5 +142,27 @@ class VFolderFactory(ModelFactory):
 
     async def before_creation(self):
         if 'user' not in self.defaults and 'group' not in self.defaults:
-            user = await UserFactory(self.app).create(self.defaults)
-            self.defaults['user'] = user.uuid
+            user = await UserFactory(self.app).create()
+            self.defaults['user'] = user['uuid']
+
+
+class VFolderInvitationFactory(ModelFactory):
+
+    model = models.vfolder_invitations
+
+    def get_creation_defaults(self, **kwargs):
+        return {
+            'permission': models.VFolderPermission('ro'),
+            'state': 'pending',
+        }
+
+    async def before_creation(self):
+        if 'vfolder' not in self.defaults:
+            vf = await VFolderFactory(self.app).create()
+            self.defaults['vfolder'] = vf['id']
+        if 'inviter' not in self.defaults:
+            user = await UserFactory(self.app).create()
+            self.defaults['inviter'] = user['email']
+        if 'invitee' not in self.defaults:
+            user = await UserFactory(self.app).create()
+            self.defaults['invitee'] = user['email']

--- a/tests/model_factory.py
+++ b/tests/model_factory.py
@@ -166,3 +166,21 @@ class VFolderInvitationFactory(ModelFactory):
         if 'invitee' not in self.defaults:
             user = await UserFactory(self.app).create()
             self.defaults['invitee'] = user['email']
+
+
+class VFolderPermissionFactory(ModelFactory):
+
+    model = models.vfolder_permissions
+
+    def get_creation_defaults(self, **kwargs):
+        return {
+            'permission': models.VFolderPermission('ro'),
+        }
+
+    async def before_creation(self):
+        if 'vfolder' not in self.defaults:
+            vf = await VFolderFactory(self.app).create()
+            self.defaults['vfolder'] = vf['id']
+        if 'user' not in self.defaults:
+            user = await UserFactory(self.app).create()
+            self.defaults['user'] = user['uuid']


### PR DESCRIPTION
Add vfolder API endpoints to
* `GET: /folders/_/shared`: list shared vfolders
* `POST: /folders/_/shared`: update the permission of shared vfolder
* `GET: /folders/invitations/list_sent`: list sent invitations
* `POST: /folders/invitations/update/{inv_id}`: update the permission of sent invitation
