### PR TITLE
Sync user keypair role

### DIFF
--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -381,12 +381,12 @@ class ModifyUser(graphene.Mutation):
                             if cnt == 0:
                                 query = (keypairs.update()
                                                  .values({'is_admin': False})
-                                                 .where(keypairs.c.uuid == row.uuid))
+                                                 .where(keypairs.c.user == row.uuid))
                                 await conn.execute(query)
                             elif row.is_admin and row.is_active:
                                 query = (keypairs.update()
                                                  .values({'is_active': False})
-                                                 .where(keypairs.c.uuid == row.uuid))
+                                                 .where(keypairs.c.user == row.uuid))
                                 await conn.execute(query)
                             cnt += 1
 


### PR DESCRIPTION
Currently, keypair's `is_admin` is not dependent with user's role. This sometimes confuse admins, especially when they change user's role from user to admin. Even though the user is changed to admin, that account cannot perform admin operations since there is no admin keypair.

This pull-request updated keypair's `is_admin` field upon user role change.

```
if user's role -> admin/superadmin
  make user's first keypair admin
if user's role -> non-admin
  make user's first keypair user
  if user have multiple active admin keypairs, inactivate them all
```