### PR TITLE
Add endpoint for updating user password

### DIFF
--- a/src/ai/backend/gateway/auth.py
+++ b/src/ai/backend/gateway/auth.py
@@ -491,6 +491,8 @@ async def update_password(request: web.Request, params: Any) -> web.Response:
     if params['new_password'] != params['new_password2']:
         log.info(log_fmt + ': new password mismtach', *log_args)
         return web.json_response({'error_msg': 'new password mismitch'}, status=400)
+
+    # Check password validaty if one of plugins provide CHECK_PASSWORD handler.
     for plugin in request.app['plugins'].values():
         hook_event_types = plugin.get_hook_event_types()
         hook_event_handlers = plugin.get_handlers()

--- a/src/ai/backend/gateway/auth.py
+++ b/src/ai/backend/gateway/auth.py
@@ -480,7 +480,7 @@ async def update_password(request: web.Request, params: Any) -> web.Response:
     domain_name = request['user']['domain_name']
     email = request['user']['email']
     log_fmt = 'AUTH.UDPATE_PASSWORD(d:{}, email:{})'
-    log_args = (params['domain'], params['email'])
+    log_args = (domain_name, email)
     log.info(log_fmt, *log_args)
     dbpool = request.app['dbpool']
 


### PR DESCRIPTION
API endpoint which enables user can update password by "the" user. This API does not support updating other fields except password, at least for now. This should be differentiated with the GraphQL API for admins which can update all user-related fields for other users.

Added endpoint:
```
POST '/update-password' (old_password, new_password, new_password2)
```