### PR TITLE
Keypair-specific SSH keypair

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -49,6 +49,7 @@ install_requires =
     async_timeout~=3.0  # to avoid pip 10 resolver issue
     attrs>=18.0         # to avoid pip 10 resolver issue
     click>=7.0
+    cryptography>=2.8
     dataclasses; python_version<"3.7"
     graphene~=2.1.0
     Jinja2~=2.10.1

--- a/src/ai/backend/gateway/auth.py
+++ b/src/ai/backend/gateway/auth.py
@@ -27,7 +27,7 @@ from ..manager.models import (
     keypairs, keypair_resource_policies, users,
 )
 from ..manager.models.user import UserRole, check_credential
-from ..manager.models.keypair import generate_keypair as _gen_keypair
+from ..manager.models.keypair import generate_keypair as _gen_keypair, generate_ssh_keypair
 from ..manager.models.group import association_groups_users, groups
 from .utils import check_api_params, set_handler_attr, get_handler_attr
 
@@ -520,6 +520,45 @@ async def update_password(request: web.Request, params: Any) -> web.Response:
     return web.json_response({}, status=200)
 
 
+@atomic
+@auth_required
+async def get_ssh_keypair(request: web.Request) -> web.Response:
+    domain_name = request['user']['domain_name']
+    access_key = request['keypair']['access_key']
+    log_fmt = 'AUTH.GET_SSH_KEYPAIR(d:{}, ak:{})'
+    log_args = (domain_name, access_key)
+    log.info(log_fmt, *log_args)
+    dbpool = request.app['dbpool']
+    async with dbpool.acquire() as conn:
+        # Get SSH public key. Return partial string from the public key just for checking.
+        query = (sa.select([keypairs.c.ssh_public_key])
+                   .where(keypairs.c.access_key == access_key))
+        pubkey = await conn.scalar(query)
+    return web.json_response({'ssh_public_key': pubkey}, status=200)
+
+
+@atomic
+@auth_required
+async def refresh_ssh_keypair(request: web.Request) -> web.Response:
+    domain_name = request['user']['domain_name']
+    access_key = request['keypair']['access_key']
+    log_fmt = 'AUTH.REFRESH_SSH_KEYPAIR(d:{}, ak:{})'
+    log_args = (domain_name, access_key)
+    log.info(log_fmt, *log_args)
+    dbpool = request.app['dbpool']
+    async with dbpool.acquire() as conn:
+        pubkey, privkey = generate_ssh_keypair()
+        data = {
+            'ssh_public_key': pubkey,
+            'ssh_private_key': privkey,
+        }
+        query = (keypairs.update()
+                         .values(data)
+                         .where(keypairs.c.access_key == access_key))
+        await conn.execute(query)
+    return web.json_response(data, status=200)
+
+
 def create_app(default_cors_options):
     app = web.Application()
     app['prefix'] = 'auth'  # slashed to distinguish with "/vN/authorize"
@@ -536,6 +575,8 @@ def create_app(default_cors_options):
     cors.add(app.router.add_route('POST', '/signup', signup))
     cors.add(app.router.add_route('POST', '/signout', signout))
     cors.add(app.router.add_route('POST', '/update-password', update_password))
+    cors.add(app.router.add_route('GET', '/ssh-keypair', get_ssh_keypair))
+    cors.add(app.router.add_route('POST', '/ssh-keypair', refresh_ssh_keypair))
     return app, [auth_middleware]
 
 

--- a/src/ai/backend/gateway/auth.py
+++ b/src/ai/backend/gateway/auth.py
@@ -576,7 +576,7 @@ def create_app(default_cors_options):
     cors.add(app.router.add_route('POST', '/signout', signout))
     cors.add(app.router.add_route('POST', '/update-password', update_password))
     cors.add(app.router.add_route('GET', '/ssh-keypair', get_ssh_keypair))
-    cors.add(app.router.add_route('POST', '/ssh-keypair', refresh_ssh_keypair))
+    cors.add(app.router.add_route('PATCH', '/ssh-keypair', refresh_ssh_keypair))
     return app, [auth_middleware]
 
 

--- a/src/ai/backend/manager/models/alembic/versions/0262e50e90e0_add_ssh_keypair_into_keypair.py
+++ b/src/ai/backend/manager/models/alembic/versions/0262e50e90e0_add_ssh_keypair_into_keypair.py
@@ -1,0 +1,60 @@
+"""add_ssh_keypair_into_keypair
+
+Revision ID: 0262e50e90e0
+Revises: 4b7b650bc30e
+Create Date: 2019-12-12 07:19:48.052928
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+from ai.backend.manager.models import keypairs
+from cryptography.hazmat.primitives import serialization as crypto_serialization
+from cryptography.hazmat.primitives.asymmetric import rsa
+from cryptography.hazmat.backends import default_backend as crypto_default_backend
+
+
+# revision identifiers, used by Alembic.
+revision = '0262e50e90e0'
+down_revision = '4b7b650bc30e'
+branch_labels = None
+depends_on = None
+
+
+def generate_ssh_keypair():
+    key = rsa.generate_private_key(
+        backend=crypto_default_backend(),
+        public_exponent=65537,
+        key_size=2048
+    )
+    private_key = key.private_bytes(
+        crypto_serialization.Encoding.PEM,
+        crypto_serialization.PrivateFormat.TraditionalOpenSSL,
+        crypto_serialization.NoEncryption()
+    ).decode("utf-8")
+    public_key = key.public_key().public_bytes(
+        crypto_serialization.Encoding.OpenSSH,
+        crypto_serialization.PublicFormat.OpenSSH
+    ).decode("utf-8")
+    return (public_key, private_key)
+
+
+def upgrade():
+    op.add_column('keypairs', sa.Column('ssh_public_key', sa.String(length=750), nullable=True))
+    op.add_column('keypairs', sa.Column('ssh_private_key', sa.String(length=2000), nullable=True))
+
+    # Fill in SSH keypairs in every keypairs.
+    conn = op.get_bind()
+    query = sa.select([keypairs])
+    rows = conn.execute(query).fetchall()
+    for row in rows:
+        pubkey, privkey = generate_ssh_keypair()
+        query = (sa.update(keypairs)
+                   .values(ssh_public_key=pubkey,
+                           ssh_private_key=privkey))
+        conn.execute(query)
+
+
+def downgrade():
+    op.drop_column('keypairs', 'ssh_public_key')
+    op.drop_column('keypairs', 'ssh_private_key')

--- a/src/ai/backend/manager/models/alembic/versions/0262e50e90e0_add_ssh_keypair_into_keypair.py
+++ b/src/ai/backend/manager/models/alembic/versions/0262e50e90e0_add_ssh_keypair_into_keypair.py
@@ -50,8 +50,8 @@ def upgrade():
     for row in rows:
         pubkey, privkey = generate_ssh_keypair()
         query = (sa.update(keypairs)
-                   .values(ssh_public_key=pubkey,
-                           ssh_private_key=privkey))
+                   .values(ssh_public_key=pubkey, ssh_private_key=privkey)
+                   .where(keypairs.c.access_key == row.access_key))
         conn.execute(query)
 
 

--- a/src/ai/backend/manager/models/keypair.py
+++ b/src/ai/backend/manager/models/keypair.py
@@ -83,7 +83,6 @@ class KeyPair(graphene.ObjectType):
     def from_row(cls, row):
         if row is None:
             return None
-        ssh_public_key = row['ssh_public_key'][:20] + '...'
         return cls(
             user_id=row['user_id'],
             access_key=row['access_key'],
@@ -98,7 +97,7 @@ class KeyPair(graphene.ObjectType):
             rate_limit=row['rate_limit'],
             num_queries=row['num_queries'],
             user=row['user'],
-            ssh_public_key=ssh_public_key
+            ssh_public_key=row['ssh_public_key'],
         )
 
     async def resolve_vfolders(self, info):
@@ -229,6 +228,7 @@ class CreateKeyPair(graphene.Mutation):
 
             # Create keypair.
             ak, sk = generate_keypair()
+            pubkey, privkey = generate_ssh_keypair()
             data = {
                 'user_id': user_id,
                 'access_key': ak,
@@ -240,6 +240,8 @@ class CreateKeyPair(graphene.Mutation):
                 'rate_limit': props.rate_limit,
                 'num_queries': 0,
                 'user': user_uuid,
+                'ssh_public_key': pubkey,
+                'ssh_private_key': privkey,
             }
             insert_query = (keypairs.insert().values(data))
             try:

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -259,8 +259,9 @@ class CreateUser(graphene.Mutation):
                     o = User.from_row(await result.first())
 
                     # Create user's first access_key and secret_key.
-                    from .keypair import generate_keypair, keypairs
+                    from .keypair import generate_keypair, generate_ssh_keypair, keypairs
                     ak, sk = generate_keypair()
+                    pubkey, privkey = generate_ssh_keypair()
                     is_admin = True if data['role'] in [UserRole.SUPERADMIN, UserRole.ADMIN] else False
                     kp_data = {
                         'user_id': email,
@@ -273,6 +274,8 @@ class CreateUser(graphene.Mutation):
                         'rate_limit': 10000,
                         'num_queries': 0,
                         'user': o.uuid,
+                        'ssh_public_key': pubkey,
+                        'ssh_private_key': privkey,
                     }
                     query = (keypairs.insert().values(kp_data))
                     await conn.execute(query)

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -524,6 +524,19 @@ class AgentRegistry:
 
         # Create kernel object in PENDING state.
         async with self.dbpool.acquire() as conn, conn.begin():
+            # Feed SSH keypair if exists.
+            query = (sa.select([keypairs.c.ssh_public_key, keypairs.c.ssh_private_key])
+                       .select_from(keypairs)
+                       .where(keypairs.c.access_key == access_key))
+            result = await conn.execute(query)
+            row  = await result.fetchone()
+            if row['ssh_public_key'] and row['ssh_private_key']:
+                internal_data = {} if internal_data is None else internal_data
+                internal_data['ssh_keypair'] = {
+                    'public_key': row['ssh_public_key'],
+                    'private_key': row['ssh_private_key'],
+                }
+
             kernel_id = uuid.uuid4()
             query = kernels.insert().values({
                 'id': kernel_id,


### PR DESCRIPTION
Current SSH keypair used to connect to a container is created per container-basis. That means, user has to change private key for SSH/SFTP client, everytime a container is destroyed and created. Furthermore, when user spawns multiple containers and wants to connect to them alternately, the user has to change private key every time they connect to another container.

User can create `.ssh` virtual folder and store public key in `authorized_keys` to use the same private key. However, this method is not possible when group virtual folder is the only allowed type.

To ease the pain in those cases, this pull request supports per-keypair SSH keypair. When new keypair is created, manager automatically generates a new SSH keypair and saves them in DB (`keypairs.c.ssh_public_key` and `keypairs.c.ssh_private_key`). This keypair is passed to the kernel creation step by `internal_data`. Then, the agent uses the information to mount `./ssh/authorized_keys` (stores public key) and `id_container` (private key).

Also, I added two API endpoints for getting and refreshing SSH keypair like below. There are no parameters for the endpoints.

```
GET  /auth/ssh-keypair
POST /auth/ssh-keypair
```

This pull-request is branched from 19.09 version.