### PR TITLE
Implement dotfiles

### DIFF
--- a/src/ai/backend/gateway/dotfile.py
+++ b/src/ai/backend/gateway/dotfile.py
@@ -1,0 +1,201 @@
+import json
+import logging
+import re
+import uuid
+
+from aiohttp import web
+import aiohttp_cors
+import sqlalchemy as sa
+import trafaret as t
+from typing import Any, Tuple
+import yaml
+
+from ai.backend.common import msgpack, validators as tx
+from ai.backend.common.logging import BraceStyleAdapter
+from ai.backend.common.types import SessionTypes
+
+from .auth import auth_required
+from .exceptions import (
+    InvalidAPIParameters, DotfileCreationFailed,
+    DotfileNotFound, DotfileAlreadyExists
+)
+from .manager import READ_ALLOWED, server_status_required
+from .typing import CORSOptions, Iterable, WebMiddleware
+from .utils import check_api_params, get_access_key_scopes
+
+from ..manager.models import (
+    keypairs
+)
+from ..manager.models.keypair import query_available_dotfiles, Dotfile, MAXIMUM_DOTFILE_SIZE
+
+log = BraceStyleAdapter(logging.getLogger('ai.backend.gateway.dotfile'))
+
+
+def validate_path(path: str) -> bool:
+    reserved_words = [r'^\.local$', r'^\.local\/', r'^\.ssh/authorized_keys$']
+    if not path.startswith('.'):
+        return False
+    for regex_reserved in [re.compile(x) for x in reserved_words]:
+        if regex_reserved.match(path):
+            return False
+    return True
+
+
+@server_status_required(READ_ALLOWED)
+@auth_required
+@check_api_params(t.Dict(
+    {
+        t.Key('data'): t.String,
+        t.Key('path'): t.String,
+        t.Key('permission', default='755'): t.Null | t.Regexp(r'^[0-9]{3}$', re.ASCII),
+        t.Key('owner_access_key', default=None): t.Null | t.String,
+    }
+))
+async def create(request: web.Request, params: Any) -> web.Response:
+    requester_access_key, owner_access_key = await get_access_key_scopes(request, params)
+    log.info('CREATE (ak:{0}/{1})',
+             requester_access_key, owner_access_key if owner_access_key != requester_access_key else '*')
+    user_uuid = request['user']['uuid']
+    dbpool = request.app['dbpool']
+
+    async with dbpool.acquire() as conn, conn.begin():
+        path: str = params['path']
+        dotfiles, leftover_space = await query_available_dotfiles(conn, owner_access_key)
+        if leftover_space == 0:
+            raise DotfileCreationFailed('No leftover space for dotfile storage')
+        if len(dotfiles) == 100:
+            raise DotfileCreationFailed('Dotfile creation limit reached')
+        if not validate_path(path):
+            raise InvalidAPIParameters(path)
+        duplicate = [x for x in dotfiles if x['path'] == path]
+        if len(duplicate) > 0:
+            raise DotfileAlreadyExists
+        new_dotfiles = list(dotfiles)
+        new_dotfiles.append({'path': path, 'perm': params['permission'], 'data': params['data']})
+        dotfile_packed = msgpack.packb(new_dotfiles)
+        if len(dotfile_packed) > MAXIMUM_DOTFILE_SIZE:
+            raise DotfileCreationFailed('No leftover space for dotfile storage')
+        
+        query = (keypairs.update()
+                         .values(dotfiles=dotfile_packed)
+                         .where(keypairs.c.access_key == owner_access_key))
+        await conn.execute(query)
+    return web.json_response({})
+
+
+@auth_required
+@server_status_required(READ_ALLOWED)
+@check_api_params(t.Dict({
+    t.Key('path', default=None): t.Null | t.String,
+    t.Key('owner_access_key', default=None): t.Null | t.String,
+}))
+async def list_or_get(request: web.Request, params: Any) -> web.Response:
+    resp = []
+    dbpool = request.app['dbpool']
+    access_key = request['keypair']['access_key']
+
+    requester_access_key, owner_access_key = await get_access_key_scopes(request, params)
+    log.info('LIST_OR_GET (ak:{0}/{1})',
+             requester_access_key, owner_access_key if owner_access_key != requester_access_key else '*')
+    async with dbpool.acquire() as conn:
+        if params['path']:
+            dotfiles, _ = await query_available_dotfiles(conn, owner_access_key)
+            for dotfile in dotfiles:
+                if dotfile['path'] == params['path']:
+                    return web.json_response(dotfile)
+            raise DotfileNotFound
+        else:
+            dotfiles, _ = await query_available_dotfiles(conn, access_key)
+            for entry in dotfiles:
+                resp.append({
+                    'path': entry['path'],
+                    'permission': entry['perm'],
+                    'data': entry['data']
+                })
+            return web.json_response(resp)
+
+
+@server_status_required(READ_ALLOWED)
+@auth_required
+@check_api_params(t.Dict(
+    {
+        t.Key('data'): t.String,
+        t.Key('path'): t.String,
+        t.Key('permission', default='644'): t.Null | t.Regexp(r'^[0-9]{3}$', re.ASCII),
+        t.Key('owner_access_key', default=None): t.Null | t.String,
+    }
+))
+async def update(request: web.Request, params: Any) -> web.Response:
+    requester_access_key, owner_access_key = await get_access_key_scopes(request, params)
+    log.info('CREATE (ak:{0}/{1})',
+             requester_access_key, owner_access_key if owner_access_key != requester_access_key else '*')
+    user_uuid = request['user']['uuid']
+    dbpool = request.app['dbpool']
+
+    async with dbpool.acquire() as conn, conn.begin():
+        path: str = params['path']
+        dotfiles, _ = await query_available_dotfiles(conn, owner_access_key)
+        new_dotfiles = [x for x in dotfiles if x['path'] != path]
+        if len(new_dotfiles) == len(dotfiles):
+            raise DotfileNotFound
+
+        new_dotfiles.append({'path': path, 'perm': params['permission'], 'data': params['data']})
+        dotfile_packed = msgpack.packb(new_dotfiles)
+        if len(dotfile_packed) > MAXIMUM_DOTFILE_SIZE:
+            raise DotfileCreationFailed('No leftover space for dotfile storage')
+        
+        query = (keypairs.update()
+                         .values(dotfiles=dotfile_packed)
+                         .where(keypairs.c.access_key == owner_access_key))
+        await conn.execute(query)
+    return web.json_response({})
+
+
+@auth_required
+@server_status_required(READ_ALLOWED)
+@check_api_params(
+    t.Dict({
+        t.Key('owner_access_key', default=None): t.Null | t.String,
+    })
+)
+async def delete(request: web.Request, params: Any) -> web.Response:
+    dbpool = request.app['dbpool']
+    path = request.match_info['dotfile_path']
+
+    requester_access_key, owner_access_key = await get_access_key_scopes(request, params)
+    log.info('DELETE (ak:{0}/{1})',
+             requester_access_key, owner_access_key if owner_access_key != requester_access_key else '*')
+
+    async with dbpool.acquire() as conn, conn.begin():
+        dotfiles, _ = await query_available_dotfiles(conn, owner_access_key)
+        new_dotfiles = [x for x in dotfiles if x['path'] != path]
+        if len(new_dotfiles) == len(dotfiles):
+            raise DotfileNotFound
+        dotfile_packed = msgpack.packb(new_dotfiles)
+        query = (keypairs.update()
+                         .values(dotfiles=dotfile_packed)
+                         .where(keypairs.c.access_key == owner_access_key))
+        await conn.execute(query)
+        return web.json_response({'success': True})
+
+
+async def init(app: web.Application) -> None:
+    pass
+
+
+async def shutdown(app: web.Application) -> None:
+    pass
+
+
+def create_app(default_cors_options: CORSOptions) -> Tuple[web.Application, Iterable[WebMiddleware]]:
+    app = web.Application()
+    app.on_startup.append(init)
+    app.on_shutdown.append(shutdown)
+    app['api_versions'] = (4, 5)
+    cors = aiohttp_cors.setup(app, defaults=default_cors_options)
+    cors.add(app.router.add_route('POST', '', create))
+    cors.add(app.router.add_route('GET', '', list_or_get))
+    cors.add(app.router.add_route('PATCH', '', update))
+    cors.add(app.router.add_route('DELETE', '', delete))
+
+    return app, []

--- a/src/ai/backend/gateway/dotfile.py
+++ b/src/ai/backend/gateway/dotfile.py
@@ -47,7 +47,7 @@ def validate_path(path: str) -> bool:
     {
         t.Key('data'): t.String,
         t.Key('path'): t.String,
-        t.Key('permission', default='755'): t.Null | t.Regexp(r'^[0-9]{3}$', re.ASCII),
+        t.Key('permission'): t.Regexp(r'^[0-9]{3}$', re.ASCII),
         t.Key('owner_access_key', default=None): t.Null | t.String,
     }
 ))
@@ -121,7 +121,7 @@ async def list_or_get(request: web.Request, params: Any) -> web.Response:
     {
         t.Key('data'): t.String,
         t.Key('path'): t.String,
-        t.Key('permission', default='644'): t.Null | t.Regexp(r'^[0-9]{3}$', re.ASCII),
+        t.Key('permission'): t.Regexp(r'^[0-9]{3}$', re.ASCII),
         t.Key('owner_access_key', default=None): t.Null | t.String,
     }
 ))
@@ -155,12 +155,13 @@ async def update(request: web.Request, params: Any) -> web.Response:
 @server_status_required(READ_ALLOWED)
 @check_api_params(
     t.Dict({
+        t.Key('path'): t.String,
         t.Key('owner_access_key', default=None): t.Null | t.String,
     })
 )
 async def delete(request: web.Request, params: Any) -> web.Response:
     dbpool = request.app['dbpool']
-    path = request.match_info['dotfile_path']
+    path = params['path']
 
     requester_access_key, owner_access_key = await get_access_key_scopes(request, params)
     log.info('DELETE (ak:{0}/{1})',

--- a/src/ai/backend/gateway/exceptions.py
+++ b/src/ai/backend/gateway/exceptions.py
@@ -179,6 +179,21 @@ class VFolderAlreadyExists(web.HTTPBadRequest, BackendError):
     error_title = 'The virtual folder already exists with the same name.'
 
 
+class DotfileCreationFailed(web.HTTPBadRequest, BackendError):
+    error_type  = 'https://api.backend.ai/probs/generic-bad-request'
+    error_title = 'Dotfile creation has failed.'
+
+
+class DotfileAlreadyExists(web.HTTPBadRequest, BackendError):
+    error_type  = 'https://api.backend.ai/probs/generic-bad-request'
+    error_title = 'Dotfile already exists.'
+
+
+class DotfileNotFound(web.HTTPNotFound, BackendError):
+    error_type  = 'https://api.backend.ai/probs/generic-not-found'
+    error_title = 'Requested Dotfile not found.'
+
+
 class QuotaExceeded(web.HTTPPreconditionFailed, BackendError):
     error_type  = 'https://api.backend.ai/probs/quota-exceeded'
     error_title = 'You have reached your resource limit.'

--- a/src/ai/backend/gateway/server.py
+++ b/src/ai/backend/gateway/server.py
@@ -476,6 +476,7 @@ async def server_main(loop: asyncio.AbstractEventLoop,
         '.scaling_group',
         '.session_template',
         '.image',
+        '.dotfile',
     ]
     app = build_root_app(pidx, _args[0], subapp_pkgs=subapp_pkgs)
 

--- a/src/ai/backend/gateway/server.py
+++ b/src/ai/backend/gateway/server.py
@@ -476,7 +476,7 @@ async def server_main(loop: asyncio.AbstractEventLoop,
         '.scaling_group',
         '.session_template',
         '.image',
-        '.dotfile',
+        '.userconfig',
     ]
     app = build_root_app(pidx, _args[0], subapp_pkgs=subapp_pkgs)
 

--- a/src/ai/backend/manager/models/alembic/versions/0262e50e90e0_add_ssh_keypair_into_keypair.py
+++ b/src/ai/backend/manager/models/alembic/versions/0262e50e90e0_add_ssh_keypair_into_keypair.py
@@ -45,7 +45,7 @@ def upgrade():
 
     # Fill in SSH keypairs in every keypairs.
     conn = op.get_bind()
-    query = sa.select([keypairs])
+    query = sa.select([keypairs.c.access_key]).select_from(keypairs)
     rows = conn.execute(query).fetchall()
     for row in rows:
         pubkey, privkey = generate_ssh_keypair()

--- a/src/ai/backend/manager/models/alembic/versions/1e8531583e20_add_dotfile_column_to_keypairs.py
+++ b/src/ai/backend/manager/models/alembic/versions/1e8531583e20_add_dotfile_column_to_keypairs.py
@@ -19,12 +19,8 @@ depends_on = None
 def upgrade():
     op.add_column(
         'keypairs',
-        sa.Column('dotfiles', sa.LargeBinary(length=64 * 1024), nullable=True)
+        sa.Column('dotfiles', sa.LargeBinary(length=64 * 1024), nullable=False, server_default='\\x90')
     )
-    connection = op.get_bind()
-    query = "UPDATE keypairs SET dotfiles = '\\x90'"
-    connection.execute(query)
-    op.alter_column('keypairs', 'dotfiles', nullable=False)
 
 
 def downgrade():

--- a/src/ai/backend/manager/models/alembic/versions/1e8531583e20_add_dotfile_column_to_keypairs.py
+++ b/src/ai/backend/manager/models/alembic/versions/1e8531583e20_add_dotfile_column_to_keypairs.py
@@ -1,0 +1,31 @@
+"""Add dotfile column to keypairs
+
+Revision ID: 1e8531583e20
+Revises: ce209920f654
+Create Date: 2020-01-17 15:59:09.367691
+
+"""
+from alembic import op
+import sqlalchemy as sa
+from ai.backend.manager.models import keypairs
+
+# revision identifiers, used by Alembic.
+revision = '1e8531583e20'
+down_revision = 'ce209920f654'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column(
+        'keypairs',
+        sa.Column('dotfiles', sa.LargeBinary(length=64 * 1024), nullable=True)
+    )
+    connection = op.get_bind()
+    query = "UPDATE keypairs SET dotfiles = '\\x90'"
+    connection.execute(query)
+    op.alter_column('keypairs', 'dotfiles', nullable=False)
+
+
+def downgrade():
+    op.drop_column('keypairs', 'dotfiles')

--- a/src/ai/backend/manager/models/keypair.py
+++ b/src/ai/backend/manager/models/keypair.py
@@ -2,7 +2,7 @@ import asyncio
 import base64
 from collections import OrderedDict
 import secrets
-from typing import Sequence
+from typing import Sequence, List, Union, TypedDict, Tuple
 
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa
@@ -12,6 +12,8 @@ from graphene.types.datetime import DateTime as GQLDateTime
 import sqlalchemy as sa
 from sqlalchemy.sql.expression import false
 import psycopg2 as pg
+
+from ai.backend.common import msgpack
 
 from .base import (
     metadata, ForeignKeyIDColumn,
@@ -23,8 +25,12 @@ __all__: Sequence[str] = (
     'keypairs',
     'KeyPair', 'KeyPairInput',
     'CreateKeyPair', 'ModifyKeyPair', 'DeleteKeyPair',
+    'Dotfile', 'MAXIMUM_DOTFILE_SIZE',
+    'query_available_dotfiles'
 )
 
+
+MAXIMUM_DOTFILE_SIZE = 64 * 1024  # 61 KiB
 
 keypairs = sa.Table(
     'keypairs', metadata,
@@ -49,6 +55,8 @@ keypairs = sa.Table(
     sa.Column('resource_policy', sa.String(length=256),
               sa.ForeignKey('keypair_resource_policies.name'),
               nullable=False),
+    # dotfiles column, \x90 means empty list in msgpack
+    sa.Column('dotfiles', sa.LargeBinary(length=MAXIMUM_DOTFILE_SIZE), nullable=False, default=b'\x90')
 )
 
 
@@ -306,6 +314,12 @@ class DeleteKeyPair(graphene.Mutation):
         return await simple_db_mutate(cls, info.context, delete_query)
 
 
+class Dotfile(TypedDict):
+    data: str
+    path: str
+    perm: str
+
+
 def generate_keypair():
     '''
     AWS-like access key and secret key generation.
@@ -334,3 +348,12 @@ def generate_ssh_keypair():
         crypto_serialization.PublicFormat.OpenSSH
     ).decode("utf-8")
     return (public_key, private_key)
+
+
+async def query_available_dotfiles(conn, access_key) -> Tuple[List[Dotfile], int]:
+    query = (sa.select([keypairs.c.dotfiles])
+               .select_from(keypairs)
+               .where(keypairs.c.access_key == access_key))
+    packed_dotfile = await conn.scalar(query)
+    rows = msgpack.unpackb(packed_dotfile)
+    return rows, MAXIMUM_DOTFILE_SIZE - len(packed_dotfile)

--- a/src/ai/backend/manager/models/keypair.py
+++ b/src/ai/backend/manager/models/keypair.py
@@ -26,7 +26,7 @@ __all__: Sequence[str] = (
     'KeyPair', 'KeyPairInput',
     'CreateKeyPair', 'ModifyKeyPair', 'DeleteKeyPair',
     'Dotfile', 'MAXIMUM_DOTFILE_SIZE',
-    'query_available_dotfiles'
+    'query_owned_dotfiles'
 )
 
 
@@ -350,7 +350,7 @@ def generate_ssh_keypair():
     return (public_key, private_key)
 
 
-async def query_available_dotfiles(conn, access_key) -> Tuple[List[Dotfile], int]:
+async def query_owned_dotfiles(conn, access_key) -> Tuple[List[Dotfile], int]:
     query = (sa.select([keypairs.c.dotfiles])
                .select_from(keypairs)
                .where(keypairs.c.access_key == access_key))

--- a/src/ai/backend/manager/models/keypair.py
+++ b/src/ai/backend/manager/models/keypair.py
@@ -2,7 +2,7 @@ import asyncio
 import base64
 from collections import OrderedDict
 import secrets
-from typing import Sequence, List, Union, TypedDict, Tuple
+from typing import Sequence, List, TypedDict, Tuple
 
 from cryptography.hazmat.primitives import serialization as crypto_serialization
 from cryptography.hazmat.primitives.asymmetric import rsa

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -590,14 +590,16 @@ class AgentRegistry:
 
         # Create kernel object in PENDING state.
         async with self.dbpool.acquire() as conn, conn.begin():
-            # Feed SSH keypair if exists.
-            query = (sa.select([keypairs.c.ssh_public_key, keypairs.c.ssh_private_key])
+            # Feed SSH keypair and dotfiles if exists.
+            query = (sa.select([keypairs.c.ssh_public_key, keypairs.c.ssh_private_key, keypairs.c.dotfiles])
                        .select_from(keypairs)
                        .where(keypairs.c.access_key == access_key))
             result = await conn.execute(query)
             row  = await result.fetchone()
+            dotfiles = msgpack.unpackb(row['dotfiles'])
+            internal_data = {} if internal_data is None else internal_data
+            internal_data.update({'dotfiles': dotfiles})
             if row['ssh_public_key'] and row['ssh_private_key']:
-                internal_data = {} if internal_data is None else internal_data
                 internal_data['ssh_keypair'] = {
                     'public_key': row['ssh_public_key'],
                     'private_key': row['ssh_private_key'],

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -591,7 +591,9 @@ class AgentRegistry:
         # Create kernel object in PENDING state.
         async with self.dbpool.acquire() as conn, conn.begin():
             # Feed SSH keypair and dotfiles if exists.
-            query = (sa.select([keypairs.c.ssh_public_key, keypairs.c.ssh_private_key, keypairs.c.dotfiles])
+            query = (sa.select([keypairs.c.ssh_public_key,
+                                keypairs.c.ssh_private_key,
+                                keypairs.c.dotfiles])
                        .select_from(keypairs)
                        .where(keypairs.c.access_key == access_key))
             result = await conn.execute(query)


### PR DESCRIPTION
This PR resolves issue lablup/backend.ai#98. 

# What has changed?
- Added `dotfiles` column to `keypairs` table
- New `/dotfile` endpoint for basic CRUD operation of dotfiles
  - `GET /dotfile`: Lists all available dotfiles per user
  - `GET /dotfile?path=<SOMEPATH>`: Returns information of dotfile with given path
  - `POST /dotfile`: Creates new dotfile 
  - `PATCH /dotfile`: Updates dotfile with given patgh
  - `DELETE /dotfile?path=<SOMEPATH>: Deletes dotfile from user with given path
- Manager now passes `dotfiles` list inside `internal_data` column to agent when creating kernel