### PR TITLE
Append agent ids when fetching image list

### DIFF
--- a/src/ai/backend/gateway/etcd.py
+++ b/src/ai/backend/gateway/etcd.py
@@ -271,6 +271,7 @@ class ConfigServer:
         installed = (
             await self.context['redis_image'].scard(image_ref.canonical)
         ) > 0
+        installed_agents = await self.context['redis_image'].smembers(image_ref.canonical)
 
         res_limits = []
         for slot_key, slot_range in item['resource'].items():
@@ -304,6 +305,7 @@ class ConfigServer:
             'resource_limits': res_limits,
             'supported_accelerators': accels,
             'installed': installed,
+            'installed_agents': installed_agents,
         }
 
     async def _check_image(self, reference: str) -> ImageRef:

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -29,6 +29,7 @@ class Image(graphene.ObjectType):
     resource_limits = graphene.List(ResourceLimit)
     supported_accelerators = graphene.List(graphene.String)
     installed = graphene.Boolean()
+    installed_agents = graphene.List(graphene.String)
     # legacy field
     hash = graphene.String()
 
@@ -50,6 +51,7 @@ class Image(graphene.ObjectType):
                 for v in data['resource_limits']],
             supported_accelerators=data['supported_accelerators'],
             installed=data['installed'],
+            installed_agents=data.get('installed_agents', []),
             # legacy
             hash=data['digest'],
         )


### PR DESCRIPTION
Simple addition of `installed_agents` field in fetching images.

In client-side, there is a need to know which image is installed in which agents.