### PR TITLE
Fix a bogus error due to missing livestat while agents starting up

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -5,3 +5,6 @@ coverage:
     project:
       default:
         threshold: 5%
+    patch:
+      default:
+        threshold: 5%

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -130,8 +130,11 @@ class Agent(graphene.ObjectType):
             lambda: rs.get(str(self.id), encoding=None))
         if live_stat is not None:
             live_stat = msgpack.unpackb(live_stat)
-            return float(live_stat['node']['cpu_util']['pct'])
-        return 0
+            try:
+                return float(live_stat['node']['cpu_util']['pct'])
+            except (KeyError, TypeError, ValueError):
+                return 0.0
+        return 0.0
 
     async def resolve_mem_cur_bytes(self, info):
         rs = info.context['redis_stat']
@@ -139,7 +142,10 @@ class Agent(graphene.ObjectType):
             lambda: rs.get(str(self.id), encoding=None))
         if live_stat is not None:
             live_stat = msgpack.unpackb(live_stat)
-            return float(live_stat['node']['mem']['current']) if live_stat else 0
+            try:
+                return int(live_stat['node']['mem']['current'])
+            except (KeyError, TypeError, ValueError):
+                return 0
         return 0
 
     async def resolve_computations(self, info, status=None):


### PR DESCRIPTION
* When an agent starts up, there is a short period (a few seconds) that
  the agent information is available in the manager database but the
  live per-node statistics are not arrived yet.

* During this period, resolving a few node statistics fields in the
  GraphQL's Agent schema results in a bogus HTTP 400 error.

* Let the manager report zero values when the statistics are not
  available.