### PR TITLE
Auto-fill the minimum resource slots for intrinsic slots only

### DIFF
--- a/src/ai/backend/gateway/defs.py
+++ b/src/ai/backend/gateway/defs.py
@@ -1,7 +1,10 @@
-# Redis database IDs depending on purposes
+"""
+Common definitions/constants used throughout the API gateway.
+"""
 
 from typing import Final
 
+# Redis database IDs depending on purposes
 REDIS_STAT_DB: Final = 0
 REDIS_RLIM_DB: Final = 1
 REDIS_LIVE_DB: Final = 2

--- a/src/ai/backend/gateway/etcd.py
+++ b/src/ai/backend/gateway/etcd.py
@@ -183,6 +183,7 @@ from ai.backend.common.docker import (
     login as registry_login,
 )
 from .auth import superadmin_required
+from ..manager.defs import INTRINSIC_SLOTS
 from .exceptions import InvalidAPIParameters, ServerMisconfiguredError
 from .manager import ManagerStatus
 from .typing import CORSOptions, WebMiddleware
@@ -608,12 +609,8 @@ class ConfigServer:
         try:
             ret = current_resource_slots.get()
         except LookupError:
-            intrinsic_slots = {
-                SlotName('cpu'): SlotTypes('count'),
-                SlotName('mem'): SlotTypes('bytes'),
-            }
             configured_slots = await self._get_resource_slots()
-            ret = {**intrinsic_slots, **configured_slots}
+            ret = {**INTRINSIC_SLOTS, **configured_slots}
             current_resource_slots.set(ret)
         return ret
 

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -1,0 +1,13 @@
+"""
+Common definitions/constants used throughout the manager.
+"""
+
+from typing import Final
+
+from ai.backend.common.types import SlotName, SlotTypes
+
+
+INTRINSIC_SLOTS: Final = {
+    SlotName('cpu'): SlotTypes('count'),
+    SlotName('mem'): SlotTypes('bytes'),
+}

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -39,6 +39,7 @@ from ai.backend.common.types import (
     SlotTypes,
 )
 from ai.backend.common.logging import BraceStyleAdapter
+from .defs import INTRINSIC_SLOTS
 from ..gateway.exceptions import (
     BackendError, InvalidAPIParameters,
     InstanceNotFound,
@@ -532,9 +533,10 @@ class AgentRegistry:
                     'Your resource request has resource type(s) '
                     'not supported by the image.')
 
-            # If the resource is not specified, fill them with image minimums.
+            # If intrinsic resources are not specified,
+            # fill them with image minimums.
             for k, v in requested_slots.items():
-                if v is None or v == 0:
+                if (v is None or v == 0) and k in INTRINSIC_SLOTS:
                     requested_slots[k] = image_min_slots[k]
         else:
             # Handle the legacy clients (prior to v19.03)


### PR DESCRIPTION
This PR is only for v19.12 (master).

* When there are mutually exclusive resource slot definitions such as
  cuda.device and cuda.shares at the same time, any pending sessions
  with one of those slots cannot be scheduled, because agents with both
  slots do not exist but pending session requests are created with both
  slots with the image's minimum required slots.

* Let the manager auto-fill the per-image minimum required resource slots
  for intrinsic slots only (cpu and mem).

* This slightly breaks the backward compatibility for CLI users who
  spawn GPU-acceleratored sessions, since they MUST SPECIFY either
  cuda.device or cuda.shares EXPLICITLY ALWAYS.