### PR TITLE
Favor CPU agents for session creation requests without accelerators

### DIFF
--- a/src/ai/backend/manager/scheduler/fifo.py
+++ b/src/ai/backend/manager/scheduler/fifo.py
@@ -22,22 +22,20 @@ from . import (
 
 def key_by_requested_slots(
     agent: AgentContext,
-    requested_slot: ResourceSlot,
+    requested_slots: ResourceSlot,
 ) -> Tuple[int, ResourceSlot]:
     unused_slot_keys = set()
-    for k, v in requested_slot.items():
+    for k, v in requested_slots.items():
         if v == Decimal(0):
             unused_slot_keys.add(k)
     num_extras = 0
     for k, v in agent.available_slots.items():
         if k in unused_slot_keys and v > Decimal(0):
             num_extras += 1
-    if num_extras > 0:
-        # Put back agents with extra slot types
-        # (e.g., accelerators)
-        return (0, agent.available_slots)
-    # Put front agents with exactly required slot types
-    return (1, agent.available_slots)
+    # Put back agents with more extra slot types
+    # (e.g., accelerators)
+    # Also put front agents with exactly required slot types
+    return (-num_extras, agent.available_slots)
 
 
 class FIFOSlotScheduler(AbstractScheduler):

--- a/src/ai/backend/manager/scheduler/fifo.py
+++ b/src/ai/backend/manager/scheduler/fifo.py
@@ -1,9 +1,11 @@
 from __future__ import annotations
 
+from decimal import Decimal
 from typing import (
     Any, Optional,
     Sequence,
     Mapping,
+    Tuple,
 )
 
 from ai.backend.common.types import (
@@ -16,6 +18,26 @@ from . import (
     PendingSession,
     ExistingSession,
 )
+
+
+def key_by_requested_slots(
+    agent: AgentContext,
+    requested_slot: ResourceSlot,
+) -> Tuple[int, ResourceSlot]:
+    unused_slot_keys = set()
+    for k, v in requested_slot.items():
+        if v == Decimal(0):
+            unused_slot_keys.add(k)
+    num_extras = 0
+    for k, v in agent.available_slots.items():
+        if k in unused_slot_keys and v > Decimal(0):
+            num_extras += 1
+    if num_extras > 0:
+        # Put back agents with extra slot types
+        # (e.g., accelerators)
+        return (0, agent.available_slots)
+    # Put front agents with exactly required slot types
+    return (1, agent.available_slots)
 
 
 class FIFOSlotScheduler(AbstractScheduler):
@@ -41,7 +63,9 @@ class FIFOSlotScheduler(AbstractScheduler):
                 possible_agents.append(agent)
         if possible_agents:
             chosen_agent = \
-                max(possible_agents, key=lambda a: a.available_slots)
+                max(possible_agents,
+                    key=lambda a: key_by_requested_slots(a,
+                                                         pending_session.requested_slots))
             return chosen_agent.agent_id
         return None
 
@@ -69,6 +93,8 @@ class LIFOSlotScheduler(AbstractScheduler):
                 possible_agents.append(agent)
         if possible_agents:
             chosen_agent = \
-                max(possible_agents, key=lambda a: a.available_slots)
+                max(possible_agents,
+                    key=lambda a: key_by_requested_slots(a,
+                                                         pending_session.requested_slots))
             return chosen_agent.agent_id
         return None

--- a/tests/manager/test_scheduler.py
+++ b/tests/manager/test_scheduler.py
@@ -76,6 +76,42 @@ def example_agents():
 
 
 @pytest.fixture
+def example_mixed_agents():
+    return [
+        AgentContext(
+            agent_id=AgentId('i-gpu'),
+            agent_addr='10.0.1.1:6001',
+            scaling_group='sg01',
+            available_slots=ResourceSlot({
+                'cpu': Decimal('4.0'),
+                'mem': Decimal('4096'),
+                'cuda.shares': Decimal('4.0'),
+            }),
+            occupied_slots=ResourceSlot({
+                'cpu': Decimal('0'),
+                'mem': Decimal('0'),
+                'cuda.shares': Decimal('0'),
+            }),
+        ),
+        AgentContext(
+            agent_id=AgentId('i-cpu'),
+            agent_addr='10.0.2.1:6001',
+            scaling_group='sg02',
+            available_slots=ResourceSlot({
+                'cpu': Decimal('3.0'),
+                'mem': Decimal('2560'),
+                'cuda.shares': Decimal('0'),
+            }),
+            occupied_slots=ResourceSlot({
+                'cpu': Decimal('0'),
+                'mem': Decimal('0'),
+                'cuda.shares': Decimal('0'),
+            }),
+        ),
+    ]
+
+
+@pytest.fixture
 def example_agents_first_one_assigned():
     return [
         AgentContext(
@@ -219,7 +255,7 @@ def example_pending_sessions():
             target_sgroup_names=[],
             **_common_dummy_for_pending_session,
         ),
-        PendingSession(
+        PendingSession(  # cpu-only
             kernel_id=pending_kernel_ids[2],
             access_key=AccessKey('user03'),
             session_name='es01',
@@ -307,6 +343,30 @@ def test_fifo_scheduler(example_agents, example_pending_sessions, example_existi
 
     agent_id = scheduler.assign_agent(example_agents, picked_session)
     assert agent_id == AgentId('i-001')
+
+
+def test_fifo_scheduler_favor_cpu_for_requests_without_accelerators(
+    example_mixed_agents,
+    example_pending_sessions,
+):
+    scheduler = FIFOSlotScheduler({})
+    for idx in range(3):
+        picked_session_id = scheduler.pick_session(
+            example_total_capacity,
+            example_pending_sessions,
+            [])
+        assert picked_session_id == example_pending_sessions[0].kernel_id
+        picked_session = _find_and_pop_picked_session(
+            example_pending_sessions, picked_session_id)
+        agent_id = scheduler.assign_agent(example_mixed_agents, picked_session)
+        if idx == 0:
+            assert agent_id is None
+        elif idx == 1:
+            assert agent_id == AgentId('i-gpu')
+        elif idx == 2:
+            # It should favor the CPU-only agent if the requested slots
+            # do not include accelerators.
+            assert agent_id == AgentId('i-cpu')
 
 
 def test_lifo_scheduler(example_agents, example_pending_sessions, example_existing_sessions):


### PR DESCRIPTION
Let's update the scheduler to favor CPU agents for session creation requests without accelerators.
But still, when CPU agents are full, those sessions must be scheduled on available GPU agents.

Internal ticket: OP#198
