### PR TITLE
fix: error on fetching docker registry list

### DIFF
--- a/src/ai/backend/gateway/etcd.py
+++ b/src/ai/backend/gateway/etcd.py
@@ -794,9 +794,9 @@ async def get_docker_registries(request) -> web.Response:
     '''
     log.info('ETCD.GET_DOCKER_REGISTRIES ()')
     etcd = request.app['registry'].config_server.etcd
-    known_registries = await get_known_registries(etcd)
+    _registries = await get_known_registries(etcd)
     # ``yarl.URL`` is not JSON-serializable, so we need to represent it as string.
-    known_registries = {k: v.human_repr() for k, v in known_registries.items()}
+    known_registries: Mapping[str, str] = {k: v.human_repr() for k, v in _registries.items()}
     return web.json_response(known_registries, status=200)
 
 

--- a/src/ai/backend/gateway/etcd.py
+++ b/src/ai/backend/gateway/etcd.py
@@ -795,6 +795,8 @@ async def get_docker_registries(request) -> web.Response:
     log.info('ETCD.GET_DOCKER_REGISTRIES ()')
     etcd = request.app['registry'].config_server.etcd
     known_registries = await get_known_registries(etcd)
+    # ``yarl.URL`` is not JSON-serializable, so we need to represent it as string.
+    known_registries = {k: v.human_repr() for k, v in known_registries.items()}
     return web.json_response(known_registries, status=200)
 
 


### PR DESCRIPTION
This pull-request resolves https://github.com/lablup/backend.ai/issues/176.

Convert `yarl.URL` object to string before JSON response in fetching docker registry list.