### PR TITLE
fix: allow group level allowed hosts for user

### DIFF
--- a/src/ai/backend/gateway/etcd.py
+++ b/src/ai/backend/gateway/etcd.py
@@ -794,9 +794,9 @@ async def get_docker_registries(request) -> web.Response:
     '''
     log.info('ETCD.GET_DOCKER_REGISTRIES ()')
     etcd = request.app['registry'].config_server.etcd
-    known_registries = await get_known_registries(etcd)
+    _registries = await get_known_registries(etcd)
     # ``yarl.URL`` is not JSON-serializable, so we need to represent it as string.
-    known_registries = {k: v.human_repr() for k, v in known_registries.items()}
+    known_registries: Mapping[str, str] = {k: v.human_repr() for k, v in _registries.items()}
     return web.json_response(known_registries, status=200)
 
 

--- a/src/ai/backend/gateway/etcd.py
+++ b/src/ai/backend/gateway/etcd.py
@@ -795,6 +795,8 @@ async def get_docker_registries(request) -> web.Response:
     log.info('ETCD.GET_DOCKER_REGISTRIES ()')
     etcd = request.app['registry'].config_server.etcd
     known_registries = await get_known_registries(etcd)
+    # ``yarl.URL`` is not JSON-serializable, so we need to represent it as string.
+    known_registries = {k: v.human_repr() for k, v in known_registries.items()}
     return web.json_response(known_registries, status=200)
 
 

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -234,8 +234,12 @@ async def create(request: web.Request, params: Any) -> web.Response:
             group_id = group_id_or_name
         if not unmanaged_path:
             # Check resource policy's allowed_vfolder_hosts
-            allowed_hosts = await get_allowed_vfolder_hosts_by_group(conn, resource_policy,
-                                                                     domain_name, group_id)
+            if group_id is not None:
+                allowed_hosts = await get_allowed_vfolder_hosts_by_group(conn, resource_policy,
+                                                                         domain_name, group_id)
+            else:
+                allowed_hosts = await get_allowed_vfolder_hosts_by_user(conn, resource_policy,
+                                                                        domain_name, user_uuid)
             if folder_host not in allowed_hosts:
                 raise InvalidAPIParameters('You are not allowed to use this vfolder host.')
             vfroot = (request.app['VFOLDER_MOUNT'] / folder_host /


### PR DESCRIPTION
This pull request resolves an issue that a user folder cannot be created if `allowed_vfolder_hosts` is set only in the group-level (namely, host is not set in domain-/keypair-policy-level).

The cause of the problem is that the `allowed_vfolder_hosts` specified at the group level is not used when creating a user folder. Fixed to call `get_allowed_vfolder_hosts_by_user` instead of `get_allowed_vfolder_hosts_by_group` if there is no `group_id` parameter when creating a folder (meaning the request tries to create a user folder).