### PR TITLE
feat: API to rename file inside a virtual folder

### DIFF
--- a/changes/266.feature
+++ b/changes/266.feature
@@ -1,0 +1,1 @@
+Add API to rename a file/directory inside a virtual folder.

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -798,6 +798,46 @@ async def tus_session_headers(request, params):
 @vfolder_permission_required(VFolderPermission.RW_DELETE)
 @check_api_params(
     t.Dict({
+        t.Key('target_path'): t.String,
+        t.Key('new_name'): t.String,
+    }))
+async def rename_file(request: web.Request, params: Any, row: VFolderRow) -> web.Response:
+    folder_name = request.match_info['name']
+    access_key = request['keypair']['access_key']
+    log.info('VFOLDER.RENAME_FILE (ak:{}, vf:{}, target_path:{}, new_name:{})',
+             access_key, folder_name, params['target_path'], params['new_name'])
+    folder_path = get_folder_hostpath(row, request.app)
+    ops = []
+    try:
+        target_path = (folder_path / params['target_path']).resolve(strict=True)
+        target_path.relative_to(folder_path)
+        new_path = target_path.parent / params['new_name']
+        # Ensure new file is in the same directory.
+        if len(params['new_name'].split('/')) > 1:
+            raise InvalidAPIParameters('New name should not be a path')
+        if new_path.exists():
+            raise InvalidAPIParameters('File already exists:', params['new_name'])
+    except FileNotFoundError:
+        raise InvalidAPIParameters('No such target file')
+    except ValueError:
+        raise InvalidAPIParameters('The requested path is out of the folder')
+    ops.append(functools.partial(target_path.rename, new_path))
+
+    def _do_ops():
+        for op in ops:
+            op()
+
+    loop = current_loop()
+    await loop.run_in_executor(None, _do_ops)
+    resp: Dict[str, Any] = {}
+    return web.json_response(resp, status=200)
+
+
+@auth_required
+@server_status_required(READ_ALLOWED)
+@vfolder_permission_required(VFolderPermission.READ_WRITE)
+@check_api_params(
+    t.Dict({
         t.Key('files'): t.List[t.String],
         t.Key('recursive', default=False): t.ToBool,
     }))
@@ -1884,6 +1924,7 @@ def create_app(default_cors_options):
     cors.add(add_route('POST',   r'/{name}/mkdir', mkdir))
     cors.add(add_route('POST',   r'/{name}/upload', upload))
     cors.add(add_route('POST',   r'/{name}/create_upload_session', create_tus_upload_session))
+    cors.add(add_route('POST',   r'/{name}/rename_file', rename_file))
     cors.add(add_route('DELETE', r'/{name}/delete_files', delete_files))
     cors.add(add_route('GET',    r'/{name}/download', download))
     cors.add(add_route('GET',    r'/{name}/download_single', download_single))

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -814,11 +814,11 @@ async def rename_file(request: web.Request, params: Any, row: VFolderRow) -> web
         new_path = target_path.parent / params['new_name']
         # Ensure new file is in the same directory.
         if len(params['new_name'].split('/')) > 1:
-            raise InvalidAPIParameters('New name should not be a path')
+            raise InvalidAPIParameters('New name should not be a path: ' + params['new_name'])
         if new_path.exists():
-            raise InvalidAPIParameters('File already exists:', params['new_name'])
+            raise InvalidAPIParameters('File already exists: ' + params['new_name'])
     except FileNotFoundError:
-        raise InvalidAPIParameters('No such target file')
+        raise InvalidAPIParameters('No such target file: ' + params['target_path'])
     except ValueError:
         raise InvalidAPIParameters('The requested path is out of the folder')
     ops.append(functools.partial(target_path.rename, new_path))


### PR DESCRIPTION
Add an endpoint to rename a file or a directory inside a virtual folder.

`/vfolders/{vfolder-name}/rename_file`
  - `target_path`: (`str`) path to a target file or directory
  - `new_name`: (`str`) new name of the file

* If `target_path` does not exist, error will be returned.
* `new_name` should be a plain string, not a path like `/home/work/test.file`.
  - It should be "rename", not "move" to a different directory.
* If there is already a file with `new_name`, error will be returned, not overwriting it.