### PR TITLE
fix: Prevent destroying kernels in PREPARING/PULLING status

### DIFF
--- a/changes/270.fix
+++ b/changes/270.fix
@@ -1,0 +1,1 @@
+Prevent destruction of kernels in PREPARING/PULLING statuses

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -42,7 +42,9 @@ from ..gateway.exceptions import (
     KernelExecutionFailed, KernelRestartFailed,
     ScalingGroupNotFound,
     VFolderNotFound,
-    AgentError)
+    AgentError,
+    GenericForbidden,
+)
 from .models import (
     agents, kernels, keypairs, vfolders,
     keypair_resource_policies,
@@ -807,6 +809,8 @@ class AgentRegistry:
                         (str(kernel.id), 'force-terminated'),
                     )
                     return {'status': 'cancelled'}
+                elif kernel.status in (KernelStatus.PREPARING, KernelStatus.PULLING):
+                    raise GenericForbidden('Cannot destory kernels in preparing/pulling status')
                 if kernel.status not in (KernelStatus.ERROR, KernelStatus.TERMINATING):
                     # This is allowed, but if agents are working normally,
                     # the session will become invisible and unaccessible but STILL occupy the actual
@@ -851,6 +855,8 @@ class AgentRegistry:
                         (str(kernel.id), 'user-requested'),
                     )
                     return {'status': 'cancelled'}
+                elif kernel.status in (KernelStatus.PREPARING, KernelStatus.PULLING):
+                    raise GenericForbidden('Cannot destory kernels in preparing/pulling status')
                 else:
                     if kernel.role == 'master':
                         # The master session is terminated; decrement the user's concurrency counter


### PR DESCRIPTION
NOTE: This restriction will be removed in 20.03 series.