### PR TITLE
fix: remove unwanted nested dict empty key("")

### DIFF
--- a/changes/275.fix
+++ b/changes/275.fix
@@ -1,0 +1,1 @@
+Remove unwanted empty key while setting etcd config with nested dict.

--- a/src/ai/backend/gateway/etcd.py
+++ b/src/ai/backend/gateway/etcd.py
@@ -840,7 +840,8 @@ async def set_config(request: web.Request, params: Any) -> web.Response:
                 inner_prefix = prefix if k == '' else f'{prefix}/{k}'
                 if isinstance(v, Mapping):
                     flatten(inner_prefix, v)
-                updates[inner_prefix] = v
+                else:
+                    updates[inner_prefix] = v
 
         flatten(params['key'], params['value'])
         # TODO: chunk support if there are too many keys


### PR DESCRIPTION
This PR fixes an issue where an unwanted value entered into an empty key ("") when settings Etcd configs with nested keys-values dictionary through `set_config`.

For example, when a client request to `POST /config/set` with following body,

```javascript
key: "resource"
value: {
  "cpu": {
     "min": "1"
  },
  "mem": {
    "min": "256m"
  }
}
```

actual keys/values in Etcd is filled like below.

```javascript
"resource": {
  "cpu": {
    "": "{'min': '1'}",
    "min": "1"
  },
  "mem": {
    "": "{'min': '256m'}",
    "min": "256m"
  }
}
```