### PR TITLE
feat: execute POST_SIGNUP hook after sign up

### DIFF
--- a/changes/286.feature
+++ b/changes/286.feature
@@ -1,0 +1,1 @@
+Execute POST_SIGNUP hook after sign up.

--- a/src/ai/backend/gateway/auth.py
+++ b/src/ai/backend/gateway/auth.py
@@ -572,6 +572,7 @@ async def signup(request: web.Request, params: Any) -> web.Response:
         # which determine the user should be allowed to sign up or not per plugin bases.
         extra_params = copy.deepcopy(params)
         extra_params.pop('email')
+        extra_params['config_server'] = request.app['config_server']
         checked_user = await _handler(params['email'], **extra_params)
         if not checked_user['success']:
             reason = checked_user.get('reason', 'signup not allowed')

--- a/src/ai/backend/gateway/exceptions.py
+++ b/src/ai/backend/gateway/exceptions.py
@@ -1,9 +1,8 @@
 '''
 This module defines a series of Backend.AI-specific errors based on HTTP Error
 classes from aiohttp.
-Raising a BackendError automatically is automatically mapped to a corresponding
-HTTP error response with RFC7807-style JSON-encoded description in its response
-body.
+Raising a BackendError is automatically mapped to a corresponding HTTP error
+response with RFC7807-style JSON-encoded description in its response body.
 
 In the client side, you should use "type" field in the body to distinguish
 canonical error types beacuse "title" field may change due to localization and

--- a/src/ai/backend/manager/plugin/__init__.py
+++ b/src/ai/backend/manager/plugin/__init__.py
@@ -1,0 +1,22 @@
+from typing import Mapping
+
+from ai.backend.common.plugin import PluginRegistry
+
+
+def get_plugin_handlers_by_type(plugins: Mapping[str, PluginRegistry], ev_type: str):
+    """
+    Yield all plugin handlers with ``ev_type`` event type.
+
+    For example, if ``ev_type`` is ``'CHECK_USER'``, every plugin handlers
+    associated with that event type will be yielded.
+    """
+    for plugin in plugins.values():
+        hook_event_types = plugin.get_hook_event_types()
+        hook_event_handlers = plugin.get_handlers()
+        for ev_types in hook_event_types:
+            if ev_type not in ev_types._member_names_:
+                continue
+            for ev_handlers in hook_event_handlers:
+                for ev_handler in ev_handlers:
+                    if ev_types[ev_type] == ev_handler[0]:
+                        yield ev_handler[1]

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -314,17 +314,18 @@ async def create_app_and_client(test_config, event_loop):
             scheduler_opts = {}
         _non_ctx_registers = []
         _cleanup_ctxs = []
-        for ctx in cleanup_contexts:
-            if ctx.__name__ in ['config_server_register', 'webapp_plugins_register']:
-                _non_ctx_registers.append(ctx)
-            else:
-                _cleanup_ctxs.append(ctx)
+        if cleanup_contexts is not None:
+            for ctx in cleanup_contexts:
+                if ctx.__name__ in ['config_server_register', 'webapp_plugins_register']:
+                    _non_ctx_registers.append(ctx)
+                else:
+                    _cleanup_ctxs.append(ctx)
         app = build_root_app(0, test_config,
                              cleanup_contexts=_cleanup_ctxs,
                              subapp_pkgs=subapp_pkgs,
                              scheduler_opts={'close_timeout': 10, **scheduler_opts})
         for register in _non_ctx_registers:
-            await register(app)
+            await register(app)  # type: ignore
         runner = web.AppRunner(app)
         await runner.setup()
         site = web.TCPSite(

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -312,10 +312,19 @@ async def create_app_and_client(test_config, event_loop):
 
         if scheduler_opts is None:
             scheduler_opts = {}
+        _non_ctx_registers = []
+        _cleanup_ctxs = []
+        for ctx in cleanup_contexts:
+            if ctx.__name__ in ['config_server_register', 'webapp_plugins_register']:
+                _non_ctx_registers.append(ctx)
+            else:
+                _cleanup_ctxs.append(ctx)
         app = build_root_app(0, test_config,
-                             cleanup_contexts=cleanup_contexts,
+                             cleanup_contexts=_cleanup_ctxs,
                              subapp_pkgs=subapp_pkgs,
                              scheduler_opts={'close_timeout': 10, **scheduler_opts})
+        for register in _non_ctx_registers:
+            await register(app)
         runner = web.AppRunner(app)
         await runner.setup()
         site = web.TCPSite(

--- a/tests/gateway/test_auth.py
+++ b/tests/gateway/test_auth.py
@@ -7,7 +7,7 @@ from dateutil.tz import tzutc, gettz
 import pytest
 
 from ai.backend.gateway.auth import _extract_auth_params, check_date
-from ai.backend.gateway.server import config_server_ctx, database_ctx
+from ai.backend.gateway.server import config_server_register, database_ctx
 from ai.backend.gateway.exceptions import InvalidAuthParameters
 
 
@@ -83,7 +83,7 @@ def test_check_date():
 async def test_authorize(etcd_fixture, database_fixture, create_app_and_client, get_headers):
     # The auth module requires config_server and database to be set up.
     app, client = await create_app_and_client(
-        [config_server_ctx, database_ctx],
+        [config_server_register, database_ctx],
         ['.auth'])
 
     async def do_authorize(hash_type, api_version):

--- a/tests/gateway/test_events.py
+++ b/tests/gateway/test_events.py
@@ -4,7 +4,7 @@ from aiohttp import web
 import pytest
 
 from ai.backend.gateway.server import (
-    config_server_ctx, event_dispatcher_ctx, background_task_ctx,
+    config_server_register, event_dispatcher_ctx, background_task_ctx,
 )
 from ai.backend.manager.types import BackgroundTaskEventArgs
 from ai.backend.common.types import (
@@ -15,7 +15,7 @@ from ai.backend.common.types import (
 @pytest.mark.asyncio
 async def test_dispatch(etcd_fixture, create_app_and_client):
     app, client = await create_app_and_client(
-        [config_server_ctx, event_dispatcher_ctx],
+        [config_server_register, event_dispatcher_ctx],
         ['.events'],
     )
     dispatcher = app['event_dispatcher']
@@ -57,7 +57,7 @@ async def test_error_on_dispatch(etcd_fixture, create_app_and_client, event_loop
         exception_log.append(type(exc).__name__)
 
     app, client = await create_app_and_client(
-        [config_server_ctx, event_dispatcher_ctx],
+        [config_server_register, event_dispatcher_ctx],
         ['.events'],
         scheduler_opts={'exception_handler': handle_exception},
     )
@@ -97,7 +97,7 @@ async def test_error_on_dispatch(etcd_fixture, create_app_and_client, event_loop
 @pytest.mark.asyncio
 async def test_background_task(etcd_fixture, create_app_and_client):
     app, client = await create_app_and_client(
-        [config_server_ctx, event_dispatcher_ctx, background_task_ctx],
+        [config_server_register, event_dispatcher_ctx, background_task_ctx],
         ['.events'],
     )
     dispatcher = app['event_dispatcher']
@@ -150,7 +150,7 @@ async def test_background_task(etcd_fixture, create_app_and_client):
 @pytest.mark.asyncio
 async def test_background_task_fail(etcd_fixture, create_app_and_client):
     app, client = await create_app_and_client(
-        [config_server_ctx, event_dispatcher_ctx, background_task_ctx],
+        [config_server_register, event_dispatcher_ctx, background_task_ctx],
         ['.events'],
     )
     dispatcher = app['event_dispatcher']

--- a/tests/gateway/test_ratelimit.py
+++ b/tests/gateway/test_ratelimit.py
@@ -3,7 +3,7 @@ import json
 import pytest
 
 from ai.backend.gateway.server import (
-    config_server_ctx, redis_ctx, database_ctx,
+    config_server_register, redis_ctx, database_ctx,
 )
 import ai.backend.gateway.ratelimit as rlim
 
@@ -12,7 +12,7 @@ import ai.backend.gateway.ratelimit as rlim
 async def test_check_rlim_for_anonymous_query(etcd_fixture, database_fixture,
                                               create_app_and_client):
     app, client = await create_app_and_client(
-        [config_server_ctx, redis_ctx, database_ctx],
+        [config_server_register, redis_ctx, database_ctx],
         ['.auth', '.ratelimit'],
     )
     ret = await client.get('/')
@@ -27,7 +27,7 @@ async def test_check_rlim_for_authorized_query(etcd_fixture, database_fixture,
                                                create_app_and_client,
                                                get_headers):
     app, client = await create_app_and_client(
-        [config_server_ctx, redis_ctx, database_ctx],
+        [config_server_register, redis_ctx, database_ctx],
         ['.auth', '.ratelimit'],
     )
     url = '/auth/test'


### PR DESCRIPTION
This PR executes `POST_SIGNUP` plugin hook after signup, to support user email validation through cloud plugin.
- Inactivate signup user's user/keypair if `CHECK_USER` handler returns `is_active = False`. 
- Separate out the logic to iterate available plugin hook handlers into `get_plugin_handler_by_type`.

This also fixed a bug which prevented registering webapp plugin handlers in 20.03. `etcd` and plugin webapps are registered before `runner.setup()` call. `runner.setup()` freezes `on_startup` event, which prevents appending sub apps in the `cleanup_context`.