### PR TITLE
feat: add a feature to kick off user who is shared virtual folder

### DIFF
--- a/changes/288.feature
+++ b/changes/288.feature
@@ -1,0 +1,1 @@
+Add a feature to kick off user who is shared virtual folder.

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -1448,9 +1448,9 @@ async def update_shared_vfolder(request: web.Request, params: Any) -> web.Respon
         if perm is not None:
             query = (
                 sa.update(vfolder_permissions)
-                  .values(permission=VFolderPermission(perm))
-                  .where(vfolder_permissions.c.vfolder == vfolder_id)
-                  .where(vfolder_permissions.c.user == user_uuid)
+                .values(permission=VFolderPermission(perm))
+                .where(vfolder_permissions.c.vfolder == vfolder_id)
+                .where(vfolder_permissions.c.user == user_uuid)
             )
         else:
             query = (


### PR DESCRIPTION
`update_shared_vfolder` now accepts `None` values for permission, which removes virtual folder permission for a specified user.

This PR implements one item specified in https://github.com/lablup/backend.ai/issues/150.