### PR TITLE
fix: convert user's uuid as str in key getter of fetching user by uuid

### DIFF
--- a/changes/299.breaking
+++ b/changes/299.breaking
@@ -1,0 +1,1 @@
+Change the argument type of `user_id` in `user_from_uuid` GraphQL query to the generic `ID`

--- a/changes/299.fix
+++ b/changes/299.fix
@@ -1,1 +1,0 @@
-Convert user's uuid into str in key getter of fetching user by uuid

--- a/changes/299.fix
+++ b/changes/299.fix
@@ -1,1 +1,4 @@
-Fix missing conversion of `user_id` argument to UUID type when resolving the `user_from_uuid` GraphQL query
+A set of API behavior fixes
+- Fix missing conversion of `user_id` argument to UUID type when resolving the `user_from_uuid` GraphQL query
+- Exclude cancelled sessions from the active session count in the manager status API
+- Fix missing update for user's `status_info` as "admin-requested" when marked as deleted by administrators

--- a/changes/299.fix
+++ b/changes/299.fix
@@ -1,0 +1,1 @@
+Convert user's uuid into str in key getter of fetching user by uuid

--- a/changes/299.fix
+++ b/changes/299.fix
@@ -1,0 +1,1 @@
+Fix missing conversion of `user_id` argument to UUID type when resolving the `user_from_uuid` GraphQL query

--- a/src/ai/backend/gateway/manager.py
+++ b/src/ai/backend/gateway/manager.py
@@ -31,7 +31,7 @@ from .exceptions import (
 )
 from .types import CORSOptions, WebMiddleware
 from .utils import check_api_params
-from ..manager.models import agents, kernels, KernelStatus, AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES
+from ..manager.models import agents, kernels, AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES
 
 log = BraceStyleAdapter(logging.getLogger('ai.backend.gateway.manager'))
 

--- a/src/ai/backend/gateway/manager.py
+++ b/src/ai/backend/gateway/manager.py
@@ -31,7 +31,7 @@ from .exceptions import (
 )
 from .types import CORSOptions, WebMiddleware
 from .utils import check_api_params
-from ..manager.models import agents, kernels, KernelStatus
+from ..manager.models import agents, kernels, KernelStatus, AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES
 
 log = BraceStyleAdapter(logging.getLogger('ai.backend.gateway.manager'))
 
@@ -98,7 +98,7 @@ async def fetch_manager_status(request: web.Request) -> web.Response:
             query = (sa.select([sa.func.count(kernels.c.id)])
                        .select_from(kernels)
                        .where((kernels.c.role == 'master') &
-                              (kernels.c.status != KernelStatus.TERMINATED)))
+                              (kernels.c.status.in_(AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES))))
             active_sessions_num = await conn.scalar(query)
 
             nodes = [

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -1,3 +1,5 @@
+import uuid
+
 import graphene
 
 from .base import privileged_query, scoped_query
@@ -184,7 +186,7 @@ class Queries(graphene.ObjectType):
     user_from_uuid = graphene.Field(
         User,
         domain_name=graphene.String(),
-        user_id=graphene.String())
+        user_id=graphene.ID())
 
     users = graphene.List(  # legacy non-paginated list
         User,
@@ -492,7 +494,9 @@ class Queries(graphene.ObjectType):
                                      domain_name=None, user_id=None):
         manager = info.context['dlmgr']
         loader = manager.get_loader('User.by_uuid', domain_name=domain_name)
-        return await loader.load(user_id)
+        # user_id is retrieved as string since it's a GraphQL's generic ID field
+        user_uuid = uuid.UUID(user_id) if isinstance(user_id, str) else user_id
+        return await loader.load(user_uuid)
 
     @staticmethod
     async def resolve_users(executor, info, *,

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -650,7 +650,7 @@ class DeleteUser(graphene.Mutation):
                 query = (
                     users.update()
                     .values(status=UserStatus.DELETED,
-                            status_info='admin_requested')
+                            status_info='admin-requested')
                     .where(users.c.email == email)
                 )
                 result = await conn.execute(query)

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -148,6 +148,7 @@ class User(graphene.ObjectType):
     status = graphene.String()
     status_info = graphene.String()
     created_at = GQLDateTime()
+    modified_at = GQLDateTime()
     domain_name = graphene.String()
     role = graphene.String()
 
@@ -179,6 +180,7 @@ class User(graphene.ObjectType):
             status=row['status'],
             status_info=row['status_info'],
             created_at=row['created_at'],
+            modified_at=row['modified_at'],
             domain_name=row['domain_name'],
             role=row['role'],
         )

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -9,7 +9,6 @@ from typing import (
     Optional,
     Sequence,
 )
-import uuid
 
 from aiopg.sa.result import RowProxy
 import graphene
@@ -121,7 +120,6 @@ class UserGroup(graphene.ObjectType):
     async def batch_load_by_user_id(cls, context, user_ids):
         async with context['dbpool'].acquire() as conn:
             from .group import groups, association_groups_users as agus
-            user_ids = [uuid.UUID(uid) if isinstance(uid, str) else uid for uid in user_ids]
             j = agus.join(groups, agus.c.group_id == groups.c.id)
             query = (
                 sa.select([agus.c.user_id, groups.c.name, groups.c.id])
@@ -352,7 +350,6 @@ class User(graphene.ObjectType):
             elif is_active is not None:  # consider is_active field only if status is empty
                 _statuses = ACTIVE_USER_STATUSES if is_active else INACTIVE_USER_STATUSES
                 query = query.where(users.c.status.in_(_statuses))
-            user_ids = [uuid.UUID(uid) if isinstance(uid, str) else uid for uid in user_ids]
             return await batch_result(
                 context, conn, query, cls,
                 user_ids, lambda row: row['uuid'],

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -649,7 +649,8 @@ class DeleteUser(graphene.Mutation):
                 # Mark user as deleted.
                 query = (
                     users.update()
-                    .values(status=UserStatus.DELETED)
+                    .values(status=UserStatus.DELETED,
+                            status_info='admin_requested')
                     .where(users.c.email == email)
                 )
                 result = await conn.execute(query)

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -350,7 +350,7 @@ class User(graphene.ObjectType):
                 query = query.where(users.c.status.in_(_statuses))
             return await batch_result(
                 context, conn, query, cls,
-                user_ids, lambda row: row['uuid'],
+                user_ids, lambda row: str(row['uuid']),
             )
 
 


### PR DESCRIPTION
This PR fixes a bug which prevents fetching user information by user's uuid, raising following exception.

```
2020-07-11 22:07:59 ERROR graphql.execution.utils [5718] Traceback (most recent call last):                                                  │'type': <MountTypes.BIND: 'bind'>},
File "/home/adrysn/.pyenv/versions/venv-master-manager/lib/python3.8/site-packages/promise/promise.py", line 844, in handle_future_result    │{'opts': None,
resolve(future.result())                                                                                                                     │'permission': <MountPermission.READ_WRITE: 'rw'>,
File "/home/devops/backend.ai-master/manager/src/ai/backend/manager/models/base.py", line 439, in wrapped                                    │'source': PosixPath('/home/devops/vfroot/local/7a8d7a0b19e446b5a351695ed82a7a5c'),
return await resolve_func(executor, info, *args, **kwargs)                                                                                   │'target': PosixPath('/home/work/.linuxbrew'),
File "/home/devops/backend.ai-master/manager/src/ai/backend/manager/models/gql.py", line 495, in resolve_user_from_uuid                      │'type': <MountTypes.BIND: 'bind'>}],
return await loader.load(user_id)                                                                                                            │'scratch_disk_size': 0,
File "/home/adrysn/.pyenv/versions/venv-master-manager/lib/python3.8/site-packages/aiodataloader.py", line 224, in dispatch_queue_batch      │'slots': {'cpu': Decimal('6'),
raise TypeError((                                                                                                                            │'cuda.shares': Decimal('1'),
graphql.error.located_error.GraphQLLocatedError: DataLoader must be constructed with a function which accepts Iterable<key> and returns Futur│'mem': Decimal('8589934592')}}
e<Iterable<value>>, but the function did not return a Future of a Iterable with the same length as the Iterable of keys.                     │2020-07-10 16:44:38 INFO ai.backend.agent.agent [5240] lifecycle event: ContainerLifecycleEvent(kernel_id=UUID('8456de13-e4c9-46c1-b9a6-01502
Keys:                                                                                                                                        │0735867'), container_id='a7368bc9e8e210ec53fc1a5519d2917be2942b68b0ef9cf849473bae4356a3ce', event=<LifecycleEvent.START: 2>, reason='new-cont
['dfa9da54-4b28-432f-be29-c0d680c7a412']                                                                                                     │ainer-started', done_event=None, exit_code=None)
Values:                                                                                                                                      │2020-07-10 16:44:40 INFO ai.backend.agent.agent [5240] produce_event(kernel_started, k:8456de13-e4c9-46c1-b9a6-015020735867)
[None, <ai.backend.manager.models.user.User object at 0x7f52423e2fd0>]                                                                       │2020-07-10 16:44:58 INFO ai.backend.agent.server [5240] rpc::get_logs(k:8456de13-e4c9-46c1-b9a6-015020735867)
                                                                                                                                             │2020-07-10 16:45:28 INFO ai.backend.agent.server [5240] rpc::get_logs(k:8456de13-e4c9-46c1-b9a6-015020735867)
2020-07-11 22:07:59 INFO aiohttp.access [5718] 10.8.0.14 [11/Jul/2020:13:07:58 +0000] "POST /admin/graphql HTTP/1.1" 400 693 "-" "Backend.AI │2020-07-10 16:48:02 INFO ai.backend.agent.server [5240] rpc::destroy_kernel(k:8456de13-e4c9-46c1-b9a6-015020735867)
Manager Hub"
```