### PR TITLE
fix: add context for the call to from_row in simple_db_mutate_returning_item

### DIFF
--- a/changes/300.fix
+++ b/changes/300.fix
@@ -1,0 +1,1 @@
+Adds context for the call to from_row in simple_db_mutate_returning_item.

--- a/src/ai/backend/gateway/auth.py
+++ b/src/ai/backend/gateway/auth.py
@@ -557,6 +557,7 @@ async def authorize(request: web.Request, params: Any) -> web.Response:
             'access_key': keypair['access_key'],
             'secret_key': keypair['secret_key'],
             'role': user['role'],
+            'status': user['status'],
         },
     })
 

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -527,7 +527,7 @@ async def simple_db_mutate_returning_item(result_cls, context, mutation_query, *
             if result.rowcount > 0:
                 result = await conn.execute(item_query)
                 item = await result.first()
-                return result_cls(True, 'success', item_cls.from_row(item))
+                return result_cls(True, 'success', item_cls.from_row(context, item))
             else:
                 return result_cls(False, 'no matching record', None)
         except (pg.IntegrityError, sa.exc.IntegrityError) as e:

--- a/src/ai/backend/manager/models/resource_preset.py
+++ b/src/ai/backend/manager/models/resource_preset.py
@@ -1,11 +1,12 @@
 import logging
-from typing import Sequence
+from typing import Any, Mapping, Sequence
 
 import graphene
 import sqlalchemy as sa
 
 from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import ResourceSlot
+from aiopg.sa.result import RowProxy
 from .base import (
     metadata, BigInt, BinarySize, ResourceSlotColumn,
     simple_db_mutate,
@@ -40,7 +41,11 @@ class ResourcePreset(graphene.ObjectType):
     shared_memory = BigInt()
 
     @classmethod
-    def from_row(cls, context, row):
+    def from_row(
+        cls,
+        context: Mapping[str, Any],
+        row: RowProxy
+    ):
         if row is None:
             return None
         shared_memory = str(row['shared_memory']) if row['shared_memory'] else None


### PR DESCRIPTION
This PR adds `context` for the call to `from_row` in `simple_db_mutate_returning_item`.
* During creation of resource preset which uses `simple_db_mutate_returning_item`, for example, it raises error stating `unexpected error: from_row() missing 1 required positional argument: 'row'`
* Minor un-related fix: return user's status in authorize API. This will be needed by client-side to determine the user's status and show better error texts when user fails to login.