### PR TITLE
feat: add purge mutations for users, groups, and domains

### DIFF
--- a/changes/302.feature
+++ b/changes/302.feature
@@ -1,0 +1,1 @@
+Add purge mutations for users, groups, and domains.

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -201,9 +201,9 @@ class ModifyDomain(graphene.Mutation):
 
 
 class DeleteDomain(graphene.Mutation):
-    '''
+    """
     Instead of deleting the domain, just mark it as inactive.
-    '''
+    """
     allowed_roles = (UserRole.SUPERADMIN,)
 
     class Arguments:
@@ -223,12 +223,12 @@ class DeleteDomain(graphene.Mutation):
 
 
 class PurgeDomain(graphene.Mutation):
-    '''
+    """
     Completely delete domain from DB.
 
     Domain-bound kernels will also be all deleted.
     To purge domain, there should be no users and groups in the target domain.
-    '''
+    """
     allowed_roles = (UserRole.SUPERADMIN,)
 
     class Arguments:

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -20,7 +20,7 @@ from .base import (
 from .scaling_group import ScalingGroup
 from .user import UserRole
 
-log = BraceStyleAdapter(logging.getLogger('ai.backend.gateway.admin'))
+log = BraceStyleAdapter(logging.getLogger(__file__))
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -241,5 +241,11 @@ class PurgeDomain(graphene.Mutation):
             )
             user_count = await conn.scalar(query)
             assert user_count == 0, 'There are users bound to the domain. Remove users first.'
+            query = (
+                sa.select([sa.func.count()])
+                .where(groups.c.domain_name == name)
+            )
+            group_count = await conn.scalar(query)
+            assert group_count == 0, 'There are groups bound to the domain. Remove groups first.'
         query = domains.delete().where(domains.c.name == name)
         return await simple_db_mutate(cls, info.context, query)

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -233,7 +233,7 @@ class PurgeDomain(graphene.Mutation):
 
     @classmethod
     async def mutate(cls, root, info, name):
-        from ai.backend.manager.models import users
+        from . import users, groups
         async with info.context['dbpool'].acquire() as conn:
             query = (
                 sa.select([sa.func.count()])

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -233,7 +233,7 @@ class PurgeDomain(graphene.Mutation):
 
     @classmethod
     async def mutate(cls, root, info, name):
-        from ai.backend.manager.models import  users
+        from ai.backend.manager.models import users
         async with info.context['dbpool'].acquire() as conn:
             query = (
                 sa.select([sa.func.count()])

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -8,11 +8,11 @@ from .agent import (
 )
 from .domain import (
     Domain,
-    CreateDomain, ModifyDomain, DeleteDomain,
+    CreateDomain, ModifyDomain, DeleteDomain, PurgeDomain,
 )
 from .group import (
     Group,
-    CreateGroup, ModifyGroup, DeleteGroup,
+    CreateGroup, ModifyGroup, DeleteGroup, PurgeGroup,
 )
 from .image import (
     Image,
@@ -49,7 +49,7 @@ from .scaling_group import (
 )
 from .user import (
     User, UserList,
-    CreateUser, ModifyUser, DeleteUser,
+    CreateUser, ModifyUser, DeleteUser, PurgeUser,
     UserRole,
 )
 from .vfolder import (
@@ -73,16 +73,19 @@ class Mutations(graphene.ObjectType):
     create_domain = CreateDomain.Field()
     modify_domain = ModifyDomain.Field()
     delete_domain = DeleteDomain.Field()
+    purge_domain = PurgeDomain.Field()
 
     # admin only
     create_group = CreateGroup.Field()
     modify_group = ModifyGroup.Field()
     delete_group = DeleteGroup.Field()
+    purge_group = PurgeGroup.Field()
 
-    # admin only
+    # super-admin only
     create_user = CreateUser.Field()
     modify_user = ModifyUser.Field()
     delete_user = DeleteUser.Field()
+    purge_user = PurgeUser.Field()
 
     # admin only
     create_keypair = CreateKeyPair.Field()

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -320,9 +320,9 @@ class ModifyGroup(graphene.Mutation):
 
 
 class DeleteGroup(graphene.Mutation):
-    '''
+    """
     Instead of deleting the group, just mark it as inactive.
-    '''
+    """
     allowed_roles = (UserRole.ADMIN, UserRole.SUPERADMIN)
 
     class Arguments:
@@ -345,13 +345,13 @@ class DeleteGroup(graphene.Mutation):
 
 
 class PurgeGroup(graphene.Mutation):
-    '''
+    """
     Completely deletes a group from DB.
 
     Group's vfolders and their data will also be lost
     as well as the kernels run from the group.
     There is no migration of the ownership for group folders.
-    '''
+    """
     allowed_roles = (UserRole.ADMIN, UserRole.SUPERADMIN)
 
     class Arguments:

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -33,7 +33,7 @@ from .base import (
 )
 from .user import UserRole
 
-log = BraceStyleAdapter(logging.getLogger('ai.backend.gateway.admin'))
+log = BraceStyleAdapter(logging.getLogger(__file__))
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -229,7 +229,8 @@ class CreateGroup(graphene.Mutation):
         lambda name, props, **kwargs: (props.domain_name, None)
     )
     async def mutate(cls, root, info, name, props):
-        assert _rx_slug.search(name) is not None, 'invalid name format. slug format required.'
+        if _rx_slug.search(name) is None:
+            raise ValueError('invalid name format. slug format required.')
         data = {
             'name': name,
             'description': props.description,
@@ -279,10 +280,10 @@ class ModifyGroup(graphene.Mutation):
         set_if_set(props, data, 'allowed_vfolder_hosts')
         set_if_set(props, data, 'integration_id')
 
-        if 'name' in data:
-            assert _rx_slug.search(data['name']) is not None, \
-                'invalid name format. slug format required.'
-        assert props.user_update_mode in (None, 'add', 'remove',), 'invalid user_update_mode'
+        if 'name' in data and _rx_slug.search(data['name']) is None:
+            raise ValueError('invalid name format. slug format required.')
+        if props.user_update_mode not in (None, 'add', 'remove'):
+            raise ValueError('invalid user_update_mode')
         if not props.user_uuids:
             props.user_update_mode = None
         if not data and props.user_update_mode is None:

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -366,7 +366,7 @@ class PurgeGroup(graphene.Mutation):
     )
     async def mutate(cls, root, info, gid):
         async with info.context['dbpool'].acquire() as conn:
-            cls.delete_vfolders(conn, gid, info.context['config_server'])
+            await cls.delete_vfolders(conn, gid, info.context['config_server'])
         query = groups.delete().where(groups.c.id == gid)
         return simple_db_mutate(cls, info.context, query)
 

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -36,7 +36,7 @@ from .base import (
     batch_multiresult,
 )
 
-log = BraceStyleAdapter(logging.getLogger('ai.backend.gateway.admin'))
+log = BraceStyleAdapter(logging.getLogger(__file__))
 
 
 __all__: Sequence[str] = (

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -761,6 +761,7 @@ class PurgeUser(graphene.Mutation):
         :param conn: DB connection
         :param deleted_user_uuid: user's UUID who will be deleted
         :param target_user_uuid: user's UUID who will get the ownership of virtual folders
+
         :return: number of deleted rows
         """
         from . import vfolders, vfolder_invitations, vfolder_permissions
@@ -800,13 +801,13 @@ class PurgeUser(graphene.Mutation):
                 .where((vfolder_invitations.c.invitee == target_user_email) &
                        (vfolder_invitations.c.vfolder.in_(migrate_vfolder_ids)))
             )
-            a = await conn.execute(query)
+            await conn.execute(query)
             query = (
                 vfolder_permissions.delete()
                 .where((vfolder_permissions.c.user == target_user_uuid) &
                        (vfolder_permissions.c.vfolder.in_(migrate_vfolder_ids)))
             )
-            b = await conn.execute(query)
+            await conn.execute(query)
 
             rowcount = 0
             for item in migrate_updates:
@@ -839,6 +840,7 @@ class PurgeUser(graphene.Mutation):
 
         :param conn: DB connection
         :param user_uuid: user's UUID to delete virtual folders
+
         :return: number of deleted rows
         """
         from . import vfolders

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -789,7 +789,7 @@ class PurgeUser(graphene.Mutation):
         config_server,
     ) -> int:
         """
-        Delete a user's all virtual folders as well as their physical data.
+        Delete user's all virtual folders as well as their physical data.
 
         :param conn: DB connection
         :param user_uuid: user's UUID to delete virtual folders
@@ -831,7 +831,7 @@ class PurgeUser(graphene.Mutation):
         user_uuid: uuid.UUID,
     ) -> int:
         """
-        Delete a user's all kernels.
+        Delete user's all kernels.
 
         :param conn: DB connection
         :param user_uuid: user's UUID to delete kernels
@@ -854,7 +854,7 @@ class PurgeUser(graphene.Mutation):
         user_uuid: uuid.UUID,
     ) -> int:
         """
-        Delete a user's all keypairs.
+        Delete user's all keypairs.
 
         :param conn: DB connection
         :param user_uuid: user's UUID to delete keypairs

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -57,9 +57,9 @@ class PasswordColumn(TypeDecorator):
 
 
 class UserRole(str, enum.Enum):
-    '''
+    """
     User's role.
-    '''
+    """
     SUPERADMIN = 'superadmin'
     ADMIN = 'admin'
     USER = 'user'
@@ -67,9 +67,9 @@ class UserRole(str, enum.Enum):
 
 
 class UserStatus(str, enum.Enum):
-    '''
+    """
     User account status.
-    '''
+    """
     ACTIVE = 'active'
     INACTIVE = 'inactive'
     DELETED = 'deleted'
@@ -203,9 +203,9 @@ class User(graphene.ObjectType):
         status=None,
         limit=None,
     ) -> Sequence[User]:
-        '''
+        """
         Load user's information. Group names associated with the user are also returned.
-        '''
+        """
         async with context['dbpool'].acquire() as conn:
             if group_id is not None:
                 from .group import association_groups_users as agus
@@ -633,11 +633,11 @@ class ModifyUser(graphene.Mutation):
 
 
 class DeleteUser(graphene.Mutation):
-    '''
+    """
     Instead of really deleting user, just mark the account as deleted status.
 
     All related keypairs will also be inactivated.
-    '''
+    """
 
     allowed_roles = (UserRole.SUPERADMIN,)
 
@@ -680,7 +680,7 @@ class DeleteUser(graphene.Mutation):
 
 
 class PurgeUser(graphene.Mutation):
-    '''
+    """
     Delete user as well as all user-related DB informations such as keypairs, kernels, etc.
 
     If target user has virtual folders, they can be purged together or migrated to the superadmin.
@@ -693,7 +693,7 @@ class PurgeUser(graphene.Mutation):
         + else: change vfolder's owner to requested admin
 
     This action cannot be undone.
-    '''
+    """
     allowed_roles = (UserRole.SUPERADMIN,)
 
     class Arguments:


### PR DESCRIPTION
This PR adds `purge` mutations to users, groups, and domains. Those three models did not expose delete operation until now (there is delete operation, but actually what it does is to just inactivate objects) since we thought it is too dangerous. However, there are requests for this feature from customers, and we decided to expose the API by `purge` mutation.

* Add `purge` mutation for domains.
  - To purge a domain, there should be no bound groups and users.
* Add `purge` mutation for groups.
  - There is no condition to purge a group since group is not an essential ingredient for users. When a group is deleted, users belong to it just lost access to that group, but their account still functions well if there are in other groups.
  - Group's related virtual folders will also be purged together.
* Add `purge` mutation for users.
  - This will completely delete user's virtual folders, kernels, and keypairs.
  - Virtual folders shared with other users will not be deleted by default, and their ownership is migrated to the requested admin.
  - If `purge_shared_vfolders` parameter is delivered, shared virtual folders will also be deleted.

Related: OP#651.