### PR TITLE
fix: prevent purging a user, group, and domain if bound resources are being used

### DIFF
--- a/changes/306.fix
+++ b/changes/306.fix
@@ -1,0 +1,2 @@
+Prevent purging a user, group, and domain if they have active sessions and/or
+their bound resources, such as virtual folders, are being used by other sessions.

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -307,4 +307,4 @@ class PurgeDomain(graphene.Mutation):
                    (kernels.c.status.in_(AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES)))
         )
         active_kernel_count = await conn.scalar(query)
-        return True if active_kernel_count > 0 else False
+        return (active_kernel_count > 0)

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -241,7 +241,7 @@ class PurgeDomain(graphene.Mutation):
         from . import users, groups
         async with info.context['dbpool'].acquire() as conn:
             if await cls.domain_has_active_kernels(conn, name):
-                raise RuntimeError('Group has some active kernels. Terminate them first.')
+                raise RuntimeError('Domain has some active kernels. Terminate them first.')
             query = (
                 sa.select([sa.func.count()])
                 .where(users.c.domain_name == name)

--- a/src/ai/backend/manager/models/domain.py
+++ b/src/ai/backend/manager/models/domain.py
@@ -240,20 +240,22 @@ class PurgeDomain(graphene.Mutation):
     async def mutate(cls, root, info, name):
         from . import users, groups
         async with info.context['dbpool'].acquire() as conn:
+            if await cls.domain_has_active_kernels(conn, name):
+                raise RuntimeError('Group has some active kernels. Terminate them first.')
             query = (
                 sa.select([sa.func.count()])
                 .where(users.c.domain_name == name)
             )
             user_count = await conn.scalar(query)
             if user_count > 0:
-                RuntimeError('There are users bound to the domain. Remove users first.')
+                raise RuntimeError('There are users bound to the domain. Remove users first.')
             query = (
                 sa.select([sa.func.count()])
                 .where(groups.c.domain_name == name)
             )
             group_count = await conn.scalar(query)
             if group_count > 0:
-                RuntimeError('There are groups bound to the domain. Remove groups first.')
+                raise RuntimeError('There are groups bound to the domain. Remove groups first.')
 
             await cls.delete_kernels(conn, name)
         query = domains.delete().where(domains.c.name == name)
@@ -282,3 +284,27 @@ class PurgeDomain(graphene.Mutation):
         if result.rowcount > 0:
             log.info('deleted {0} domain\'s kernels ({1})', result.rowcount, domain_name)
         return result.rowcount
+
+    @classmethod
+    async def domain_has_active_kernels(
+        cls,
+        conn: SAConnection,
+        domain_name: str,
+    ) -> bool:
+        """
+        Check if the domain does not have active kernels.
+
+        :param conn: DB connection
+        :param domain_name: domain's name
+
+        :return: True if the domain has some active kernels.
+        """
+        from . import kernels, AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES
+        query = (
+            sa.select([sa.func.count()])
+            .select_from(kernels)
+            .where((kernels.c.domain_name == domain_name) &
+                   (kernels.c.status.in_(AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES)))
+        )
+        active_kernel_count = await conn.scalar(query)
+        return True if active_kernel_count > 0 else False

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -938,7 +938,7 @@ class PurgeUser(graphene.Mutation):
                    (kernels.c.status.in_(AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES)))
         )
         active_kernel_count = await conn.scalar(query)
-        return True if active_kernel_count > 0 else False
+        return (active_kernel_count > 0)
 
     @classmethod
     async def delete_kernels(

--- a/src/ai/backend/manager/models/user.py
+++ b/src/ai/backend/manager/models/user.py
@@ -716,6 +716,11 @@ class PurgeUser(graphene.Mutation):
                 user_uuid = await conn.scalar(query)
                 log.info('completly deleting user {0}...', email)
 
+                if await cls.user_vfolder_mounted_to_active_kernels(conn, user_uuid):
+                    raise RuntimeError('Some of user\'s virtual folders are mounted to active kernels')
+                if await cls.user_has_active_kernels(conn, user_uuid):
+                    raise RuntimeError('User has some active kernels. Terminate them first.')
+
                 if not purge_shared_vfolders:
                     await cls.migrate_shared_vfolders(
                         conn,
@@ -871,6 +876,64 @@ class PurgeUser(graphene.Mutation):
         if result.rowcount > 0:
             log.info('deleted {0} user\'s virtual folders ({1})', result.rowcount, user_uuid)
         return result.rowcount
+
+    @classmethod
+    async def user_vfolder_mounted_to_active_kernels(
+        cls,
+        conn: SAConnection,
+        user_uuid: uuid.UUID,
+    ) -> bool:
+        """
+        Check if no active kernel is using the user's virtual folders.
+
+        :param conn: DB connection
+        :param user_uuid: user's UUID
+
+        :return: True if a virtual folder is mounted to active kernels.
+        """
+        from . import kernels, vfolders, AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES
+        query = (
+            sa.select([vfolders.c.id])
+            .select_from(vfolders)
+            .where(vfolders.c.user == user_uuid)
+        )
+        result = await conn.execute(query)
+        user_vfolder_ids = await result.fetchall()
+        query = (
+            sa.select([kernels.c.mounts])
+            .select_from(kernels)
+            .where(kernels.c.status.in_(AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES))
+        )
+        async for row in conn.execute(query):
+            for _mount in row['mounts']:
+                vfolder_id = uuid.UUID(_mount[2])
+                if vfolder_id in user_vfolder_ids:
+                    return True
+        return False
+
+    @classmethod
+    async def user_has_active_kernels(
+        cls,
+        conn: SAConnection,
+        user_uuid: uuid.UUID,
+    ) -> bool:
+        """
+        Check if the user does not have active kernels.
+
+        :param conn: DB connection
+        :param user_uuid: user's UUID
+
+        :return: True if the user has some active kernels.
+        """
+        from . import kernels, AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES
+        query = (
+            sa.select([sa.func.count()])
+            .select_from(kernels)
+            .where((kernels.c.user_uuid == user_uuid) &
+                   (kernels.c.status.in_(AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES)))
+        )
+        active_kernel_count = await conn.scalar(query)
+        return True if active_kernel_count > 0 else False
 
     @classmethod
     async def delete_kernels(


### PR DESCRIPTION
Followup of https://github.com/lablup/backend.ai-manager/pull/302.

* Prevent purging a user when the user's virtual folders are mounted to some active sessions and/or the user has running sessions.
* Prevent purging a group when the group's virtual folders are mounted to some active sessions and/or the group has active sessions.
* Prevent purging a domain when it has active sessions.