### PR TITLE
fix: vfolder.py integer type cast to parameter size

### DIFF
--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -781,7 +781,7 @@ async def tus_upload_part(request):
             await writer.write(chunk)
 
     fs = Path(target_filename).stat().st_size
-    if fs >= params['size']:
+    if fs >= int(params['size']):
         target_path = folder_path / params['path']
         Path(target_filename).rename(target_path)
         try:


### PR DESCRIPTION
Despite the tus client sends file size parameter as integer. The server encodes parameter file size in jwt as a string. This will ensure that the parameter when it is used is integer.