### PR TITLE
Storage Proxy

### DIFF
--- a/changes/0.breaking
+++ b/changes/0.breaking
@@ -1,0 +1,1 @@
+The latest API version is now bumped to `v6.20200815`.

--- a/changes/312.breaking
+++ b/changes/312.breaking
@@ -1,5 +1,7 @@
 Configuration/DB changes are required for storage proxies
 - To use vfolders, now the storage proxy must be installed and configured.
+- The "volumes" key in the etcd must include storage proxy configurations,
+  as demonstrated in the `config/sample.volume.json` file.
 - All vfolder hosts are now in the format of "{proxy-name}:{volume-name}"
   where proxy-name is the key in the etcd and volume-name values are retrieved from
   the storage proxies at runtime.

--- a/changes/312.breaking
+++ b/changes/312.breaking
@@ -1,0 +1,8 @@
+Configuration/DB changes are required for storage proxies
+- To use vfolders, now the storage proxy must be installed and configured.
+- All vfolder hosts are now in the format of "{proxy-name}:{volume-name}"
+  where proxy-name is the key in the etcd and volume-name values are retrieved from
+  the storage proxies at runtime.
+- All `allowed_vfolder_hosts` configurations in the database must be updated to
+  the above new vfolder host format.
+- Clients should use the same vfolder host format when making API requests.

--- a/changes/312.feature
+++ b/changes/312.feature
@@ -1,0 +1,5 @@
+Add support for storage proxies
+- Storage proxies have a multi-backend architecture, so now storage-specific optimizations such as per-directory quota, performance measurements and fast metadata scanning all becomes available to Backend.AI users.
+- Offload and unify vfolder upload/download operations to storage proxies via the HTTP ranged queries and the tus.io protocol.
+- Support multiple storage proxies configured via etcd, and each storage proxy may provide multiple volumes in the mount points shared with agents.
+- Now the manager instances don't have mount points for the storage volumes, and mount/fstab management APIs skip the manager-side queries and manipulations.

--- a/config/sample.volume.json
+++ b/config/sample.volume.json
@@ -1,4 +1,11 @@
 {
-  "_mount": "/mnt/vfroot",
-  "_default_host": "local"
+  "default_host": "local:volume1",
+  "proxies": {
+    "local": {
+      "client_api": "http://127.0.0.1:6021",
+      "manager_api": "https://127.0.0.1:6022",
+      "secret": "xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+      "ssl_verify": false
+    }
+  }
 }

--- a/src/ai/backend/gateway/config.py
+++ b/src/ai/backend/gateway/config.py
@@ -114,6 +114,19 @@ shared_config_iv = t.Dict({
     }).allow_extra('*'),
 }).allow_extra('*')
 
+volume_config_iv = t.Dict({
+    t.Key('default_host'): t.String,
+    t.Key('proxies'): t.Mapping(
+        tx.Slug,
+        t.Dict({
+            t.Key('client_api'): t.String,
+            t.Key('manager_api'): t.String,
+            t.Key('secret'): t.String,
+            t.Key('ssl_verify'): t.ToBool,
+        }),
+    ),
+}).allow_extra('*')
+
 
 def load(config_path: Path = None, debug: bool = False) -> Mapping[str, Any]:
 

--- a/src/ai/backend/gateway/etcd.py
+++ b/src/ai/backend/gateway/etcd.py
@@ -84,14 +84,24 @@ Alias keys are also URL-quoted in the same way.
      + watcher
        - token: {some-secret}
    + volumes
+     # pre-20.09
      - _mount: {path-to-mount-root-for-vfolder-partitions}
      - _default_host: {default-vfolder-partition-name}
      - _fsprefix: {path-prefix-inside-host-mounts}
-     + proxies:
-       - "local": "localhost:6020"
-       - "mynas1": "proxy1:6020"
-       - "myceph1": "proxy1:6020"
-       - "mypure1": "proxy2:6020"
+     # 20.09 and later
+     - default_host: "{default-proxy}:{default-volume}"
+     + proxies:   # each proxy may provide multiple volumes
+       + "local"  # proxy name
+         - client_api: "localhost:6021"
+         - manager_api: "localhost:6022"
+         - secret: "xxxxxx..."       # for manager API
+         - ssl_verify: true | false  # for manager API
+       + "mynas1"
+         - client_api: "proxy1.example.com:6021"
+         - manager_api: "proxy1.example.com:6022"
+         - secret: "xxxxxx..."       # for manager API
+         - ssl_verify: true | false  # for manager API
+       ...
    + images
      + _aliases
        - {alias}: "{registry}/{image}:{tag}"   # {alias} is url-quoted

--- a/src/ai/backend/gateway/etcd.py
+++ b/src/ai/backend/gateway/etcd.py
@@ -87,6 +87,11 @@ Alias keys are also URL-quoted in the same way.
      - _mount: {path-to-mount-root-for-vfolder-partitions}
      - _default_host: {default-vfolder-partition-name}
      - _fsprefix: {path-prefix-inside-host-mounts}
+     + proxies:
+       - "local": "localhost:6020"
+       - "mynas1": "proxy1:6020"
+       - "myceph1": "proxy1:6020"
+       - "mypure1": "proxy2:6020"
    + images
      + _aliases
        - {alias}: "{registry}/{image}:{tag}"   # {alias} is url-quoted

--- a/src/ai/backend/gateway/server.py
+++ b/src/ai/backend/gateway/server.py
@@ -83,7 +83,11 @@ VALID_VERSIONS: Final = frozenset([
     'v4.20190615',
 
     # added mount_map parameter when creating kernel
+    # changed GraphQL query structures for multi-container bundled sessions
     'v5.20191215'
+
+    # rewrote vfolder upload/download APIs to migrate to external storage proxies
+    'v6.20200815'
 ])
 LATEST_REV_DATES: Final = {
     1: '20160915',
@@ -91,8 +95,9 @@ LATEST_REV_DATES: Final = {
     3: '20181215',
     4: '20190615',
     5: '20191215',
+    6: '20200815',
 }
-LATEST_API_VERSION: Final = 'v5.20191215'
+LATEST_API_VERSION: Final = 'v6.20200815'
 
 log = BraceStyleAdapter(logging.getLogger('ai.backend.gateway.server'))
 

--- a/src/ai/backend/gateway/server.py
+++ b/src/ai/backend/gateway/server.py
@@ -84,10 +84,10 @@ VALID_VERSIONS: Final = frozenset([
 
     # added mount_map parameter when creating kernel
     # changed GraphQL query structures for multi-container bundled sessions
-    'v5.20191215'
+    'v5.20191215',
 
     # rewrote vfolder upload/download APIs to migrate to external storage proxies
-    'v6.20200815'
+    'v6.20200815',
 ])
 LATEST_REV_DATES: Final = {
     1: '20160915',

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -1683,10 +1683,6 @@ async def umount_host(request: web.Request, params: Any) -> web.Response:
 
 
 async def init(app):
-    mount_prefix = await app['config_server'].get('volumes/_mount')
-    fs_prefix = await app['config_server'].get('volumes/_fsprefix')
-    app['VFOLDER_MOUNT'] = Path(mount_prefix)
-    app['VFOLDER_FSPREFIX'] = Path(fs_prefix.lstrip('/'))
     storage_api_connector = aiohttp.TCPConnector(ssl=False)
     app['storage_api_session'] = aiohttp.ClientSession(connector=storage_api_connector)
 

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -3,7 +3,6 @@ from datetime import datetime
 import functools
 import json
 import logging
-import os
 from pathlib import Path
 import stat
 from typing import (

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -1373,7 +1373,7 @@ async def list_mounts(request: web.Request) -> web.Response:
     all_volumes = [*await storage_manager.get_all_volumes()]
     all_mounts = [
         volume_data['path']
-        for volume_data in all_volumes
+        for proxy_name, volume_data in all_volumes
     ]
     all_vfolder_hosts = [
         f"{proxy_name}:{volume_data['name']}"

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -685,7 +685,7 @@ async def mkdir(request: web.Request, params: Any, row: VFolderRow) -> web.Respo
     }))
 async def create_download_session(request: web.Request, params: Any, row: VFolderRow) -> web.Response:
     log_fmt = 'VFOLDER.CREATE_DOWNLOAD_SESSION(ak:{}, vf:{}, path:{})'
-    log_args = (request['keypair']['access_key'], row['name'], params['file'])
+    log_args = (request['keypair']['access_key'], row['name'], params['path'])
     log.info(log_fmt, *log_args)
     unmanaged_path = row['unmanaged_path']
     storage_api_session = request.app['storage_api_session']

--- a/src/ai/backend/manager/exceptions.py
+++ b/src/ai/backend/manager/exceptions.py
@@ -1,0 +1,6 @@
+class InvalidArgument(Exception):
+    """
+    An internal exception class to represent invalid arguments in internal APIs.
+    This is wrapped as InvalidAPIParameters in web request handlers.
+    """
+    pass

--- a/src/ai/backend/manager/models/storage.py
+++ b/src/ai/backend/manager/models/storage.py
@@ -85,7 +85,7 @@ class StorageSessionManager:
         /,
         *args,
         **kwargs,
-    ) -> AsyncIterator[aiohttp.ClientResponse]:
+    ) -> AsyncIterator[Tuple[yarl.URL, aiohttp.ClientResponse]]:
         proxy_name, _ = self.split_host(vfolder_host_or_proxy_name)
         try:
             proxy_info = self._proxies[proxy_name]

--- a/src/ai/backend/manager/models/storage.py
+++ b/src/ai/backend/manager/models/storage.py
@@ -1,0 +1,102 @@
+import asyncio
+from contextlib import asynccontextmanager as actxmgr
+import itertools
+from typing import (
+    Any,
+    AsyncIterator,
+    Final,
+    Iterable,
+    Mapping,
+    Tuple,
+)
+
+import aiohttp
+import attr
+import yarl
+
+from ..exceptions import InvalidArgument
+
+
+@attr.s(auto_attribs=True, slots=True, frozen=True)
+class StorageProxyInfo:
+    session: aiohttp.ClientSession
+    secret: str
+    client_api_url: yarl.URL
+    manager_api_url: yarl.URL
+
+
+AUTH_TOKEN_HDR: Final = 'X-BackendAI-Storage-Auth-Token'
+
+
+class StorageSessionManager:
+
+    _proxies: Mapping[str, StorageProxyInfo]
+
+    def __init__(self, storage_config: Mapping[str, Any]) -> None:
+        self.config = storage_config
+        self._proxies = {}
+        for proxy_name, proxy_config in self.config['proxies'].items():
+            connector = aiohttp.TCPConnector(ssl=proxy_config['ssl_verify'])
+            session = aiohttp.ClientSession(connector=connector)
+            self._proxies[proxy_name] = StorageProxyInfo(
+                session=session,
+                secret=proxy_config['secret'],
+                client_api_url=yarl.URL(proxy_config['client_api']),
+                manager_api_url=yarl.URL(proxy_config['manager_api']),
+            )
+
+    async def aclose(self) -> None:
+        close_aws = []
+        for proxy_info in self._proxies.values():
+            close_aws.append(proxy_info.session.close())
+        await asyncio.gather(*close_aws, return_exceptions=True)
+
+    @staticmethod
+    def split_host(vfolder_host: str) -> Tuple[str, str]:
+        proxy_name, _, volume_name = vfolder_host.partition(':')
+        return proxy_name, volume_name
+
+    async def get_all_volumes(self) -> Iterable[Tuple[str, Mapping[str, Any]]]:
+        fetch_aws = []
+
+        async def _fetch(
+            proxy_name: str,
+            proxy_info: StorageProxyInfo,
+        ) -> Iterable[Tuple[str, Mapping[str, Any]]]:
+            async with proxy_info.session.request(
+                'GET', proxy_info.manager_api_url / 'volumes',
+                raise_for_status=True,
+                headers={AUTH_TOKEN_HDR: proxy_info.secret},
+            ) as resp:
+                reply = await resp.json()
+                return ((proxy_name, volume_data) for volume_data in reply['volumes'])
+
+        for proxy_name, proxy_info in self._proxies.items():
+            fetch_aws.append(_fetch(proxy_name, proxy_info))
+        results = await asyncio.gather(*fetch_aws)
+        return itertools.chain(*results)
+
+    @actxmgr
+    async def request(
+        self,
+        vfolder_host_or_proxy_name: str,
+        method: str,
+        request_relpath: str,
+        /,
+        *args,
+        **kwargs,
+    ) -> AsyncIterator[aiohttp.ClientResponse]:
+        proxy_name, _ = self.split_host(vfolder_host_or_proxy_name)
+        try:
+            proxy_info = self._proxies[proxy_name]
+        except KeyError:
+            raise InvalidArgument('There is no such storage proxy', proxy_name)
+        headers = kwargs.pop('headers', {})
+        headers[AUTH_TOKEN_HDR] = proxy_info.secret
+        async with proxy_info.session.request(
+            method, proxy_info.manager_api_url / request_relpath,
+            *args,
+            headers=headers,
+            **kwargs,
+        ) as client_resp:
+            yield proxy_info.client_api_url, client_resp


### PR DESCRIPTION
Support for the storage proxy and migrate existing vfolder operations/APIs to use the storage proxy
configured per vfolder host.

Public ticket: lablup/backend.ai#183, lablup/backend.ai#50
Internal ticket: OP#508

This work is also in conjunction with lablup/backend.ai-client-py#118 and lablup/backend.ai-client-js#17

This PR includes:
* A set of rewritten vfolder API implementations using storage proxies, via `manager.models.storage.StorageSessionManager`, with addition of a per-vfolder-host performance metric API.
* Bumped the major API version: `v6.20200815`
* A sample volume configuration for storage proxies in `config/sample.volume.json`
* Updated the etcd schema description in the `gateway.etcd` module.