### PR TITLE
fix: log detailed error messages when there are graphQl exceptions

### DIFF
--- a/changes/324.fix
+++ b/changes/324.fix
@@ -1,0 +1,1 @@
+Log detailed error messages when graphQl exceptions are raised.

--- a/src/ai/backend/gateway/admin.py
+++ b/src/ai/backend/gateway/admin.py
@@ -92,9 +92,12 @@ async def handle_gql(request: web.Request, params: Any) -> web.Response:
         errors = []
         for e in result.errors:
             if isinstance(e, GraphQLError):
-                errors.append(format_error(e))
+                errmsg = format_error(e)
+                errors.append(errmsg)
             else:
+                errmsg = {'message': str(e)}
                 errors.append({'message': str(e)})
+            log.error('ADMIN.GQL Exception: {}', errmsg)
         raise BackendGQLError(extra_data=errors)
     return web.json_response(result.data, status=200)
 

--- a/src/ai/backend/gateway/admin.py
+++ b/src/ai/backend/gateway/admin.py
@@ -96,7 +96,7 @@ async def handle_gql(request: web.Request, params: Any) -> web.Response:
                 errors.append(errmsg)
             else:
                 errmsg = {'message': str(e)}
-                errors.append({'message': str(e)})
+                errors.append(errmsg)
             log.error('ADMIN.GQL Exception: {}', errmsg)
         raise BackendGQLError(extra_data=errors)
     return web.json_response(result.data, status=200)


### PR DESCRIPTION
When an exception is raised during handling of graphQL requests, there is currently no way to know why it occurred just by reading manager logs. This minor PR logs detailed error messages upon graphQL exceptions.

I initially thought that the exception logging should be handled in `GQLLoggingMiddleware`, but it seems like that the graphQL middlewares are called only after the requests are `resolve`d,  which failed to log exceptions for un-resolved requets.