### PR TITLE
fix: hand over recursive parameter to storage proxy when delete_files

### DIFF
--- a/changes/330.fix
+++ b/changes/330.fix
@@ -1,0 +1,1 @@
+Hand over recursive parameter to storage proxy when deleting files.

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -794,6 +794,7 @@ async def delete_files(request: web.Request, params: Any, row: VFolderRow) -> we
             'volume': volume_name,
             'vfid': str(row['id']),
             'relpaths': params['files'],
+            'recursive': recursive,
         },
         raise_for_status=True,
     ):


### PR DESCRIPTION
This PR appends `recursive` parameter to deliver it to the storage proxy when deleting files.