### PR TITLE
fix: get_task_logs references deprecated etcd config

### DIFF
--- a/changes/337.feature
+++ b/changes/337.feature
@@ -1,1 +1,1 @@
-`get_task_logs` have referenced deprecated etcd config.
+**TO MERGE:** Update `get_task_logs` API to work with the storage proxy (follow-up to #312)

--- a/changes/337.feature
+++ b/changes/337.feature
@@ -1,0 +1,1 @@
+`get_task_logs` have referenced deprecated etcd config.

--- a/src/ai/backend/gateway/session.py
+++ b/src/ai/backend/gateway/session.py
@@ -1736,10 +1736,7 @@ async def get_task_logs(request: web.Request, params: Any) -> web.StreamResponse
                     prepared = True
                 await response.write(chunk)
     except aiohttp.ClientResponseError as e:
-        if e.status // 100 == 4:
-            raise StorageProxyError(status=e.status, extra_msg=e.message)
-        else:
-            raise
+        raise StorageProxyError(status=e.status, extra_msg=e.message)
     finally:
         if prepared:
             await response.write_eof()


### PR DESCRIPTION
`get_task_logs` raises an error, so a client cannot get task logs in Backend.AI 20.09. This is due to the handler still uses deprecated etcd volume configs: `volumes/_mount` and `volumes/_fsprefix`. This PR removes them and build `log_path` variable correctly by fetching information from storage-proxy.