### PR TITLE
fix: unable to invite user to a vfolder, which is shared with another user

### DIFF
--- a/changes/340.fix
+++ b/changes/340.fix
@@ -1,0 +1,1 @@
+Unable to invite user to a vfolder, which is shared with another user.

--- a/src/ai/backend/gateway/auth.py
+++ b/src/ai/backend/gateway/auth.py
@@ -544,7 +544,6 @@ async def authorize(request: web.Request, params: Any) -> web.Response:
     # ``dbpool`` parameter (if the hook needs to query to database).
     # They should return a corresponding Backend.AI user object after performing
     # their own authentication steps, like LDAP authentication, etc.
-    params['dbpool'] = dbpool  # hack to execute db commands in the hook (TODO: more general logic)
     hook_result = await request.app['hook_plugin_ctx'].dispatch(
         'AUTHORIZE',
         (params, dbpool),


### PR DESCRIPTION
Check for already-invited users should use invitee emails, not requester email. This prevented a vfolder invited by two or more users.