### PR TITLE
fix: read manager ID from keys of etcd_info

### DIFF
--- a/changes/342.fix
+++ b/changes/342.fix
@@ -1,0 +1,1 @@
+Fix a regression of the manager status API due to internal etcd data structure changes, by returning the first-seen manager ID (for HA scenarios) to keep the compatibility of API semantics

--- a/src/ai/backend/gateway/manager.py
+++ b/src/ai/backend/gateway/manager.py
@@ -102,9 +102,16 @@ async def fetch_manager_status(request: web.Request) -> web.Response:
                               (kernels.c.status.in_(AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES))))
             active_sessions_num = await conn.scalar(query)
 
+            # TODO: update logic to return information for multiple managers (HA)
+            if '' in etcd_info:
+                _id = etcd_info['']
+            elif etcd_info:
+                _id = list(etcd_info.keys())[0]
+            else:
+                _id = ''
             nodes = [
                 {
-                    'id': etcd_info[''],
+                    'id': _id,
                     'num_proc': configs['num-proc'],
                     'service_addr': str(configs['service-addr']),
                     'heartbeat_timeout': configs['heartbeat-timeout'],

--- a/src/ai/backend/gateway/vfolder.py
+++ b/src/ai/backend/gateway/vfolder.py
@@ -1833,7 +1833,7 @@ async def umount_host(request: web.Request, params: Any) -> web.Response:
     }
     if params['edit_fstab'] and resp['manager']['success']:
         fstab_path = params['fstab_path'] if params['fstab_path'] else '/etc/fstab'
-        async with aiofiles.open(fstab_path, mode='r+') as fp:
+        async with aiofiles.open(fstab_path, mode='r+') as fp:  # type: ignore
             fstab = Fstab(fp)
             await fstab.remove_by_mountpoint(str(mountpoint))
 


### PR DESCRIPTION
This PR resolves https://github.com/lablup/backend.ai/issues/177.

`fetch_manager_status` references the value of Etcd's `nodes/manager`, which is deprecated from above 20.03 (https://github.com/lablup/backend.ai-manager/blob/master/src/ai/backend/gateway/etcd.py#L136). So, the request to fetch manager's status (`/status`) raises error, and this keeps clients from displaying the manager's status.

This PR has changed to use the key-value pair under `nodes/manager`, if there is no direct value of `nodes/manager`.