### PR TITLE
fix: update compute_plugins info from heartbeat for an ALIVE agent

### DIFF
--- a/changes/350.fix
+++ b/changes/350.fix
@@ -1,0 +1,1 @@
+Update compute_plugins info from heartbeat for an ALIVE agent.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1928,6 +1928,7 @@ class AgentRegistry:
                     if row['addr'] != current_addr:
                         updates['addr'] = current_addr
                     updates['version'] = agent_info['version']
+                    updates['compute_plugins'] = agent_info['compute_plugins']
                     # occupied_slots are updated when kernels starts/terminates
                     if updates:
                         await self.config_server.update_resource_slots(slot_key_and_units)


### PR DESCRIPTION
After updating Backend.AI manager and agent, the compute plugins information is not updated unless we delete the agent information. The PR updates compute plugins inforamation when agent status is `ALIVE` as well.