### PR TITLE
fix: make aiodocker belong to prindipal dependencies

### DIFF
--- a/changes/377.fix
+++ b/changes/377.fix
@@ -1,0 +1,1 @@
+Put aiodocker in the default dependency, not testing.

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires =
     setuptools>=45.2.0
 install_requires =
     aiodataloader
-    aiodocker>=0.19.0
+    aiodocker~=0.19.1
     aiofiles~=0.6.0
     aiohttp~=3.7.3
     aiohttp_cors~=0.7

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,6 +34,7 @@ setup_requires =
     setuptools>=45.2.0
 install_requires =
     aiodataloader
+    aiodocker>=0.19.0
     aiofiles~=0.6.0
     aiohttp~=3.7.3
     aiohttp_cors~=0.7
@@ -79,7 +80,6 @@ build =
     twine>=1.14.0
     towncrier~=19.2.0
 test =
-    aiodocker~=0.18.0
     pytest~=6.1.2
     pytest-asyncio>=0.14.0  # only compatible with pytest>=5.4.0
     pytest-aiohttp


### PR DESCRIPTION
`aiodocker` is used int `registry.py`, but it is put in a test dependency. I think it should be a default dependency.