### PR TITLE
fix: remove b-prefix in background task events function

### DIFF
--- a/changes/394.fix
+++ b/changes/394.fix
@@ -1,0 +1,1 @@
+Remove b-prefix in "push_background_task_events" function

--- a/src/ai/backend/gateway/events.py
+++ b/src/ai/backend/gateway/events.py
@@ -378,7 +378,7 @@ async def push_background_task_events(
                 }
                 await resp.send(json.dumps(body), event=f"task_{task_info['status']}")
             finally:
-                await resp.send(b'{}', event="server_close")
+                await resp.send('{}', event="server_close")
         return resp
 
     # It is an ongoing task.


### PR DESCRIPTION
This PR removes b-prefix in sending server_closed due to innate code in "[aiohttp-sse](https://github.com/aio-libs/aiohttp-sse/blob/307fd35a84a66b7fb5adfd70cd5b7d709fa8508c/aiohttp_sse/__init__.py#L91)".