### PR TITLE
feat: add BACKENDAI_KERNEL_IMAGE environment variable in container

### DIFF
--- a/changes/401.feature
+++ b/changes/401.feature
@@ -1,0 +1,1 @@
+Add BACKENDAI_KERNEL_IMAGE environment variable inside a compute container.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1243,6 +1243,7 @@ class AgentRegistry:
                                     'environ': {
                                         **pending_session.environ,
                                         'BACKENDAI_KERNEL_ID': str(binding.kernel.kernel_id),
+                                        'BACKENDAI_KERNEL_IMAGE': str(binding.kernel.image_ref),
                                         'BACKENDAI_CLUSTER_ROLE': binding.kernel.cluster_role,
                                         'BACKENDAI_CLUSTER_IDX': str(binding.kernel.cluster_idx),
                                         'BACKENDAI_CLUSTER_HOST': str(binding.kernel.cluster_hostname),


### PR DESCRIPTION
Some users want to write a script which has different control flow depending on the launched kernel image.