### PR TITLE
fix: do not register sub containers to existing sessions if main container is TERMINATED

### DIFF
--- a/changes/403.fix
+++ b/changes/403.fix
@@ -1,0 +1,1 @@
+Scheduler for scaling group was entirely broken if only sub containers are running with main container is terminated.

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -18,7 +18,6 @@ from typing import (
     Union,
     TYPE_CHECKING,
 )
-import uuid
 
 from aiopg.sa.connection import SAConnection
 import aioredis

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -821,7 +821,7 @@ async def _list_existing_sessions(
             )
             items[row['session_id']] = session
     for row in rows:
-        session_id: uuid.UUID = row['session_id']
+        session_id = row['session_id']
         if session_id not in items:
             # In some cases, sub containers are still RUNNING even though main container is TERMINATED.
             # To circumvent this edge case, we skip if main container is not registered in `items`.

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -227,9 +227,9 @@ class SchedulerDispatcher(aobject):
                     start_task_args.extend(args_list)
                 except InstanceNotAvailable:
                     # Proceed to the next scaling group and come back later.
-                    pass
-                except Exception:
-                    pass
+                    log.debug('schedule({}): instance not available', sgroup_name)
+                except Exception as e:
+                    log.error('schedule({}): scheculing error!\n{}', sgroup_name, repr(e))
 
         # At this point, all scheduling decisions are made
         # and the resource occupation is committed to the database.
@@ -820,7 +820,11 @@ async def _list_existing_sessions(
             )
             items[row['session_id']] = session
     for row in rows:
-        session = items[row['session_id']]
+        session = items.get(row['session_id'])
+        if not session:
+            # In some cases, sub containers are still RUNNING even though main container is TERMINATED.
+            # To circumvent this edge case, we skip if main container is not registered in `items`.
+            continue
         session.kernels.append(KernelInfo(  # type: ignore
             kernel_id=row['id'],
             session_id=row['session_id'],

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -18,6 +18,7 @@ from typing import (
     Union,
     TYPE_CHECKING,
 )
+import uuid
 
 from aiopg.sa.connection import SAConnection
 import aioredis
@@ -820,11 +821,12 @@ async def _list_existing_sessions(
             )
             items[row['session_id']] = session
     for row in rows:
-        session = items.get(row['session_id'])
-        if not session:
+        session_id: uuid.UUID = row['session_id']
+        if session_id not in items:
             # In some cases, sub containers are still RUNNING even though main container is TERMINATED.
             # To circumvent this edge case, we skip if main container is not registered in `items`.
             continue
+        session = items[session_id]
         session.kernels.append(KernelInfo(  # type: ignore
             kernel_id=row['id'],
             session_id=row['session_id'],


### PR DESCRIPTION
In some cases, sub containers are still RUNNING even though main container is TERMINATED, which we can call broken session. In this case, the scheduler for the scaling group which contains the broken session is unable to schedule PENDING sessions at all. To circumvent this edge case, we exclude broken sessions, that do not have main container, from fetching existing session list.