### PR TITLE
fix: idle_timeout was not working due to last_access save error

### DIFF
--- a/changes/404.fix
+++ b/changes/404.fix
@@ -1,0 +1,1 @@
+Idle timeout was not working since there was a type error on saving compute session's last_access time.

--- a/src/ai/backend/gateway/config.py
+++ b/src/ai/backend/gateway/config.py
@@ -69,7 +69,7 @@ Alias keys are also URL-quoted in the same way.
          # NOTE: idle checkers get activated AFTER the app-streaming packet timeout has passed.
        - checkers
          + "timeout"
-           - treshold: "10m"
+           - threshold: "10m"
          + "utilization"
            + resource-thresholds
              + "cpu"

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -212,7 +212,7 @@ class TimeoutIdleChecker(BaseIdleChecker):
         await self._redis.set(
             f"session.{session_id}.last_access",
             f"{t:.06f}",
-            expire=max(86400, self.idle_timeout.total_seconds() * 2),
+            expire=max(86400, int(self.idle_timeout.total_seconds() * 2)),
         )
 
     async def _session_started_cb(


### PR DESCRIPTION
`expire` parameter in aioredis's `set` method explicitly requires `int` type and `float` is not allowed.