### PR TITLE
fix: Add check for pgsql version to adjust connection args

### DIFF
--- a/changes/407.fix
+++ b/changes/407.fix
@@ -1,0 +1,1 @@
+Add PostgreSQL version check to adjust connection arguments

--- a/src/ai/backend/gateway/auth.py
+++ b/src/ai/backend/gateway/auth.py
@@ -584,9 +584,9 @@ async def authorize(request: web.Request, params: Any) -> web.Response:
         )
     if user is None:
         raise AuthorizationFailed('User credential mismatch.')
-    if user.get('status') == UserStatus.BEFORE_VERIFICATION:
+    if user['status'] == UserStatus.BEFORE_VERIFICATION:
         raise AuthorizationFailed('This account needs email verification.')
-    if user.get('status') in INACTIVE_USER_STATUSES:
+    if user['status'] in INACTIVE_USER_STATUSES:
         raise AuthorizationFailed('User credential mismatch.')
     async with root_ctx.db.begin() as conn:
         query = (sa.select([keypairs.c.access_key, keypairs.c.secret_key])

--- a/src/ai/backend/gateway/server.py
+++ b/src/ai/backend/gateway/server.py
@@ -328,7 +328,7 @@ async def database_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     version_check_db = create_async_engine(url)
     async with version_check_db.connect() as conn:
         result = await conn.execute(sa.text("show server_version"))
-        major, minor = map(int, result.scalar().split("."))
+        major, minor, *_ = map(int, result.scalar().split("."))
         if (major, minor) < (11, 0):
             pgsql_connect_opts['server_settings'].pop("jit")
     await version_check_db.dispose()
@@ -559,8 +559,12 @@ def build_root_app(
         # aiohttp's cleanup contexts are just async generators, not async context managers.
         cctx_instance = cctx(app['_root.context'])
         app['_cctx_instances'].append(cctx_instance)
-        async with cctx_instance:
-            yield
+        try:
+            async with cctx_instance:
+                yield
+        except Exception as e:
+            exc_info = (type(e), e, e.__traceback__)
+            log.error('Error initializing cleanup_contexts: {0}', cctx.__name__, exc_info=exc_info)
 
     async def _call_cleanup_context_shutdown_handlers(app: web.Application) -> None:
         for cctx in app['_cctx_instances']:

--- a/src/ai/backend/gateway/server.py
+++ b/src/ai/backend/gateway/server.py
@@ -330,7 +330,7 @@ async def database_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
         result = await conn.execute(sa.text("show server_version"))
         major, minor = map(int, result.scalar().split("."))
         if (major, minor) < (11, 0):
-            pgsql_connect_opts.pop("jit")
+            pgsql_connect_opts['server_settings'].pop("jit")
     await version_check_db.dispose()
 
     root_ctx.db = create_async_engine(

--- a/src/ai/backend/gateway/server.py
+++ b/src/ai/backend/gateway/server.py
@@ -31,6 +31,7 @@ import aiotools
 import click
 from pathlib import Path
 from setproctitle import setproctitle
+import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import create_async_engine
 
 from ai.backend.common import redis
@@ -323,6 +324,15 @@ async def database_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     address = root_ctx.local_config['db']['addr']
     dbname = root_ctx.local_config['db']['name']
     url = f"postgresql+asyncpg://{urlquote(username)}:{urlquote(password)}@{address}/{urlquote(dbname)}"
+
+    version_check_db = create_async_engine(url)
+    async with version_check_db.connect() as conn:
+        result = await conn.execute(sa.text("show server_version"))
+        major, minor = map(int, result.scalar().split("."))
+        if (major, minor) < (11, 0):
+            pgsql_connect_opts.pop("jit")
+    await version_check_db.dispose()
+
     root_ctx.db = create_async_engine(
         url,
         connect_args=pgsql_connect_opts,

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -78,7 +78,9 @@ convention = {
 }
 metadata = sa.MetaData(naming_convention=convention)
 
-pgsql_connect_opts = {'server_settings': {'jit': 'off'}}
+pgsql_connect_opts = {
+    'server_settings': {'jit': 'off'}
+}
 
 
 # helper functions

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -384,7 +384,7 @@ async def query_accessible_vfolders(
                 'group_name': row.groups_name,
                 'is_owner': is_owner,
                 'permission': row.vfolders_permission,
-                'unmanaged_path': row.unmanaged_path,
+                'unmanaged_path': row.vfolders_unmanaged_path,
                 'cloneable': row.vfolders_cloneable,
             })
     return entries


### PR DESCRIPTION
This is a follow-up to #406, to keep the manager compatible with PostgreSQL v10 or older, where the JIT option is not available.