### PR TITLE
feat: share group virtual folder directly without invitation

### DIFF
--- a/changes/419.feature
+++ b/changes/419.feature
@@ -1,0 +1,1 @@
+Add an API endpoint to share/unshare a group virtual folder directly to specific users. This is to allow specified users (usually teachers with user account) can upload data/materials to a virtual folder while it is shared as read-only for other group users.

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -50,7 +50,7 @@ from ..models import (
     get_allowed_vfolder_hosts_by_user,
     verify_vfolder_name,
 )
-from .auth import admin_required, auth_required, superadmin_required
+from .auth import auth_required, superadmin_required
 from .exceptions import (
     VFolderCreationFailed, VFolderNotFound, VFolderAlreadyExists, VFolderOperationFailed,
     GenericForbidden, GenericNotFound, InvalidAPIParameters, ServerMisconfiguredError,

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -1334,8 +1334,11 @@ async def share(request: web.Request, params: Any) -> web.Response:
         query = (
             sa.select([users.c.uuid, users.c.email])
             .select_from(j)
-            .where(users.c.email.in_(params['emails']))
-            .where(users.c.email != request['user']['email'])
+            .where(
+                (users.c.email.in_(params['emails'])) &
+                (users.c.email != request['user']['email']) &
+                (agus.c.group_id == vf_info['group'])
+            )
         )
         result = await conn.execute(query)
         user_info = result.fetchall()

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -1692,14 +1692,15 @@ async def list_shared_vfolders(request: web.Request, params: Any) -> web.Respons
     target_vfid = params['vfolder_id']
     log.info('VFOLDER.LIST_SHARED_VFOLDERS (ak:{})', access_key)
     async with root_ctx.db.begin() as conn:
-        j = (vfolder_permissions
-             .join(vfolders, vfolders.c.id == vfolder_permissions.c.vfolder)
-             .join(users, users.c.uuid == vfolder_permissions.c.user))
-        query = (sa.select([vfolder_permissions,
-                            vfolders.c.id, vfolders.c.name,
-                            users.c.email])
-                   .select_from(j)
-                   .where((vfolders.c.user == request['user']['uuid'])))
+        j = (
+            vfolder_permissions
+            .join(vfolders, vfolders.c.id == vfolder_permissions.c.vfolder)
+            .join(users, users.c.uuid == vfolder_permissions.c.user)
+        )
+        query = (
+            sa.select([vfolder_permissions, vfolders.c.id, vfolders.c.name, users.c.email])
+            .select_from(j)
+        )
         if target_vfid is not None:
             query = query.where(vfolders.c.id == target_vfid)
         result = await conn.execute(query)

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -50,7 +50,7 @@ from ..models import (
     get_allowed_vfolder_hosts_by_user,
     verify_vfolder_name,
 )
-from .auth import auth_required, superadmin_required
+from .auth import admin_required, auth_required, superadmin_required
 from .exceptions import (
     VFolderCreationFailed, VFolderNotFound, VFolderAlreadyExists, VFolderOperationFailed,
     GenericForbidden, GenericNotFound, InvalidAPIParameters, ServerMisconfiguredError,

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -1368,7 +1368,7 @@ async def share(request: web.Request, params: Any) -> web.Response:
                 'user': _user,
             }))
             await conn.execute(query)
-        return web.json_response(emails_to_share, status=201)
+        return web.json_response({'shared_emails': emails_to_share}, status=201)
 
 
 @atomic
@@ -1429,7 +1429,7 @@ async def unshare(request: web.Request, params: Any) -> web.Response:
             )
         )
         await conn.execute(query)
-        return web.json_response({}, status=200)
+        return web.json_response({'unshared_emails': params['emails']}, status=200)
 
 
 @auth_required

--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -1369,7 +1369,7 @@ async def unshare(request: web.Request, params: Any) -> web.Response:
     root_ctx: RootContext = request.app['_root.context']
     access_key = request['keypair']['access_key']
     log.info('VFOLDER.UNSHARE (ak:{}, vf:{}, users:{})',
-             access_key, params['id'], ','.join(emails))
+             access_key, params['id'], ','.join(params['emails']))
     async with root_ctx.db.begin() as conn:
         # Convert users' emails to uuids.
         query = (

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -213,7 +213,6 @@ async def query_accessible_vfolders(
                 vfolders.c.id,
                 vfolders.c.host,
                 vfolders.c.usage_mode,
-                vfolders.c.permission,
                 vfolders.c.created_at,
                 vfolders.c.last_used,
                 vfolders.c.max_files,
@@ -223,6 +222,7 @@ async def query_accessible_vfolders(
                 vfolders.c.group,
                 vfolders.c.creator,
                 vfolders.c.unmanaged_path,
+                vfolders.c.permission,
                 vfolders.c.cloneable,
                 users.c.email,
             ])

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -203,8 +203,59 @@ async def query_accessible_vfolders(
     if allowed_vfolder_types is None:
         allowed_vfolder_types = ['user']  # legacy default
     entries = []
+    # User vfolders.
     if 'user' in allowed_vfolder_types:
-        # User vfolders.
+        # Scan my owned vfolders.
+        j = (vfolders.join(users, vfolders.c.user == users.c.uuid))
+        query = (
+            sa.select([
+                vfolders.c.name,
+                vfolders.c.id,
+                vfolders.c.host,
+                vfolders.c.usage_mode,
+                vfolders.c.created_at,
+                vfolders.c.last_used,
+                vfolders.c.max_files,
+                vfolders.c.max_size,
+                vfolders.c.ownership_type,
+                vfolders.c.user,
+                vfolders.c.group,
+                vfolders.c.creator,
+                vfolders.c.unmanaged_path,
+                vfolders.c.permission,
+                vfolders.c.cloneable,
+                users.c.email,
+            ])
+            .select_from(j)
+            .where(vfolders.c.user == user_uuid)
+        )
+        if extra_vf_conds is not None:
+            query = query.where(extra_vf_conds)
+        if extra_vf_user_conds is not None:
+            query = query.where(extra_vf_user_conds)
+        result = await conn.execute(query)
+        for row in result:
+            entries.append({
+                'name': row.name,
+                'id': row.id,
+                'host': row.host,
+                'usage_mode': row.usage_mode,
+                'created_at': row.created_at,
+                'last_used': row.last_used,
+                'max_size': row.max_size,
+                'max_files': row.max_files,
+                'ownership_type': row.ownership_type,
+                'user': str(row.user) if row.user else None,
+                'group': str(row.group) if row.group else None,
+                'creator': row.creator,
+                'user_email': row.email,
+                'group_name': None,
+                'is_owner': True,
+                'permission': row.permission,
+                'unmanaged_path': row.unmanaged_path,
+                'cloneable': row.cloneable,
+            })
+        # Scan vfolders shared with me.
         j = (
             vfolders.join(
                 vfolder_permissions,
@@ -232,16 +283,13 @@ async def query_accessible_vfolders(
                 vfolders.c.group,
                 vfolders.c.creator,
                 vfolders.c.unmanaged_path,
-                vfolders.c.permission,
-                vfolder_permissions.c.permission,  # override vfolder perm if exists
+                # vfolders.c.permission,
+                vfolder_permissions.c.permission,  # override vfolder perm
                 vfolders.c.cloneable,
                 users.c.email,
-            ], use_labels=True)
+            ])
             .select_from(j)
-            .where(
-                (vfolders.c.user == user_uuid) |
-                (vfolder_permissions.c.user == user_uuid)
-            )
+            .where(vfolder_permissions.c.user == user_uuid)
         )
         if extra_vf_conds is not None:
             query = query.where(extra_vf_conds)
@@ -250,26 +298,24 @@ async def query_accessible_vfolders(
         result = await conn.execute(query)
         for row in result:
             entries.append({
-                'name': row.vfolders_name,
-                'id': row.vfolders_id,
-                'host': row.vfolders_host,
-                'usage_mode': row.vfolders_usage_mode,
-                'created_at': row.vfolders_created_at,
-                'last_used': row.vfolders_last_used,
-                'max_size': row.vfolders_max_size,
-                'max_files': row.vfolders_max_files,
-                'ownership_type': row.vfolders_ownership_type,
-                'user': str(row.vfolders_user) if row.vfolders_user else None,
-                'group': str(row.vfolders_group) if row.vfolders_group else None,
-                'creator': row.vfolders_creator,
-                'user_email': row.users_email,
+                'name': row.name,
+                'id': row.id,
+                'host': row.host,
+                'usage_mode': row.usage_mode,
+                'created_at': row.created_at,
+                'last_used': row.last_used,
+                'max_size': row.max_size,
+                'max_files': row.max_files,
+                'ownership_type': row.ownership_type,
+                'user': str(row.user) if row.user else None,
+                'group': str(row.group) if row.group else None,
+                'creator': row.creator,
+                'user_email': row.email,
                 'group_name': None,
                 'is_owner': False,
-                'permission': row.vfolder_permissions_permission \
-                              if row.vfolder_permissions_permission \
-                              else row.vfolders_permission,
-                'unmanaged_path': row.vfolders_unmanaged_path,
-                'cloneable': row.vfolders_cloneable,
+                'permission': row.permission,  # not vfolders.c.permission!
+                'unmanaged_path': row.unmanaged_path,
+                'cloneable': row.cloneable,
             })
 
     if 'group' in allowed_vfolder_types:

--- a/src/ai/backend/manager/models/vfolder.py
+++ b/src/ai/backend/manager/models/vfolder.py
@@ -203,59 +203,8 @@ async def query_accessible_vfolders(
     if allowed_vfolder_types is None:
         allowed_vfolder_types = ['user']  # legacy default
     entries = []
-    # User vfolders.
     if 'user' in allowed_vfolder_types:
-        # Scan my owned vfolders.
-        j = (vfolders.join(users, vfolders.c.user == users.c.uuid))
-        query = (
-            sa.select([
-                vfolders.c.name,
-                vfolders.c.id,
-                vfolders.c.host,
-                vfolders.c.usage_mode,
-                vfolders.c.created_at,
-                vfolders.c.last_used,
-                vfolders.c.max_files,
-                vfolders.c.max_size,
-                vfolders.c.ownership_type,
-                vfolders.c.user,
-                vfolders.c.group,
-                vfolders.c.creator,
-                vfolders.c.unmanaged_path,
-                vfolders.c.permission,
-                vfolders.c.cloneable,
-                users.c.email,
-            ])
-            .select_from(j)
-            .where(vfolders.c.user == user_uuid)
-        )
-        if extra_vf_conds is not None:
-            query = query.where(extra_vf_conds)
-        if extra_vf_user_conds is not None:
-            query = query.where(extra_vf_user_conds)
-        result = await conn.execute(query)
-        for row in result:
-            entries.append({
-                'name': row.name,
-                'id': row.id,
-                'host': row.host,
-                'usage_mode': row.usage_mode,
-                'created_at': row.created_at,
-                'last_used': row.last_used,
-                'max_size': row.max_size,
-                'max_files': row.max_files,
-                'ownership_type': row.ownership_type,
-                'user': str(row.user) if row.user else None,
-                'group': str(row.group) if row.group else None,
-                'creator': row.creator,
-                'user_email': row.email,
-                'group_name': None,
-                'is_owner': True,
-                'permission': row.permission,
-                'unmanaged_path': row.unmanaged_path,
-                'cloneable': row.cloneable,
-            })
-        # Scan vfolders shared with me.
+        # User vfolders.
         j = (
             vfolders.join(
                 vfolder_permissions,
@@ -283,13 +232,16 @@ async def query_accessible_vfolders(
                 vfolders.c.group,
                 vfolders.c.creator,
                 vfolders.c.unmanaged_path,
-                # vfolders.c.permission,
-                vfolder_permissions.c.permission,  # override vfolder perm
+                vfolders.c.permission,
+                vfolder_permissions.c.permission,  # override vfolder perm if exists
                 vfolders.c.cloneable,
                 users.c.email,
-            ])
+            ], use_labels=True)
             .select_from(j)
-            .where(vfolder_permissions.c.user == user_uuid)
+            .where(
+                (vfolders.c.user == user_uuid) |
+                (vfolder_permissions.c.user == user_uuid)
+            )
         )
         if extra_vf_conds is not None:
             query = query.where(extra_vf_conds)
@@ -298,24 +250,26 @@ async def query_accessible_vfolders(
         result = await conn.execute(query)
         for row in result:
             entries.append({
-                'name': row.name,
-                'id': row.id,
-                'host': row.host,
-                'usage_mode': row.usage_mode,
-                'created_at': row.created_at,
-                'last_used': row.last_used,
-                'max_size': row.max_size,
-                'max_files': row.max_files,
-                'ownership_type': row.ownership_type,
-                'user': str(row.user) if row.user else None,
-                'group': str(row.group) if row.group else None,
-                'creator': row.creator,
-                'user_email': row.email,
+                'name': row.vfolders_name,
+                'id': row.vfolders_id,
+                'host': row.vfolders_host,
+                'usage_mode': row.vfolders_usage_mode,
+                'created_at': row.vfolders_created_at,
+                'last_used': row.vfolders_last_used,
+                'max_size': row.vfolders_max_size,
+                'max_files': row.vfolders_max_files,
+                'ownership_type': row.vfolders_ownership_type,
+                'user': str(row.vfolders_user) if row.vfolders_user else None,
+                'group': str(row.vfolders_group) if row.vfolders_group else None,
+                'creator': row.vfolders_creator,
+                'user_email': row.users_email,
                 'group_name': None,
                 'is_owner': False,
-                'permission': row.permission,  # not vfolders.c.permission!
-                'unmanaged_path': row.unmanaged_path,
-                'cloneable': row.cloneable,
+                'permission': row.vfolder_permissions_permission \
+                              if row.vfolder_permissions_permission \
+                              else row.vfolders_permission,
+                'unmanaged_path': row.vfolders_unmanaged_path,
+                'cloneable': row.vfolders_cloneable,
             })
 
     if 'group' in allowed_vfolder_types:


### PR DESCRIPTION
This PR adds API endpoints to share or unshare a group virtual folder to users directly with overriding permission. This is to allow specified users (usually teachers with user account) can upload data/materials to a group virtual folder while it is shared as read-only for all other group users (usually students).

Also, `query_accessible_vfolders` are refactored to account for the overriding permission of group virtual folders.

Only group virtual folders are directly sharable since user-type folders can be shared by invitation. Group folders are visible to every group users without user's choice, so it does not make sense to invite a group folder.