### PR TITLE
feat: add update_full_name api to update regardless of the role

### DIFF
--- a/src/ai/backend/manager/api/auth.py
+++ b/src/ai/backend/manager/api/auth.py
@@ -762,6 +762,7 @@ async def signout(request: web.Request, params: Any) -> web.Response:
         await conn.execute(query)
     return web.json_response({})
 
+
 @atomic
 @auth_required
 @check_api_params(
@@ -779,8 +780,8 @@ async def update_full_name(request: web.Request, params: Any) -> web.Response:
     async with root_ctx.db.begin() as conn:
         query = (
             sa.select([users])
-                .select_from(users)
-                .where(
+            .select_from(users)
+            .where(
                 (users.c.email == email) &
                 (users.c.domain_name == domain_name)
             )


### PR DESCRIPTION
add update_full_name to update user's full_name regardless of the role (before, the modify user_mutation is for only super admin.)

this closes #424 
it relates to [#957](https://github.com/lablup/backend.ai-webui/issues/957) in webui.