### PR TITLE
feat:  unify global-default scheduler configs and per-scaling group scheduler options

### DIFF
--- a/changes/428.feature
+++ b/changes/428.feature
@@ -1,0 +1,1 @@
+- Modify the loading process so that the scheduler can be loaded reflecting scheduler_opts.

--- a/changes/428.feature
+++ b/changes/428.feature
@@ -1,1 +1,1 @@
-- Modify the loading process so that the scheduler can be loaded reflecting scheduler_opts.
+Modify the loading process so that the scheduler can be loaded reflecting scheduler_opts.

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -244,7 +244,7 @@ class SchedulerDispatcher(aobject):
         db_conn: SAConnection,
         sgroup_name: str,
     ) -> AbstractScheduler:
-        try: 
+        try:
             query = (
                 sa.select([scaling_groups.c.scheduler, scaling_groups.c.scheduler_opts])
                 .select_from(scaling_groups)
@@ -258,8 +258,8 @@ class SchedulerDispatcher(aobject):
             log.error('_load_scheduler(): multiple scheduler', exc_info=err)
         except NoResultFound as err:
             log.error('_load_SCHEDULER(): scheduler does not exist', exc_info=err)
-        
-        return load_scheduler(scheduler_name, {**self.shared_config['plugins']['scheduler'][scheduler_name], **scheduler_opts})
+        scheduler_opts = {**self.shared_config['plugins']['scheduler'][scheduler_name], **scheduler_opts}
+        return load_scheduler(scheduler_name, scheduler_opts)
 
     async def _schedule_in_sgroup(
         self,

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -254,10 +254,10 @@ class SchedulerDispatcher(aobject):
             row = result.one()
             scheduler_name = row['scheduler']
             scheduler_opts = row['scheduler_opts']
-        except MultipleResultsFound as err:
-            log.error('_load_scheduler(): multiple scheduler', exc_info=err)
-        except NoResultFound as err:
-            log.error('_load_SCHEDULER(): scheduler does not exist', exc_info=err)
+        except MultipleResultsFound as e:
+            log.exception('_load_scheduler(): multiple scheduler! \n{}', repr(e))
+        except NoResultFound as e:
+            log.exception('_load_scheduler(): scheduler does not exist! \n{}', repr(e))
         scheduler_opts = {**self.shared_config['plugins']['scheduler'][scheduler_name], **scheduler_opts}
         return load_scheduler(scheduler_name, scheduler_opts)
 

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -23,7 +23,6 @@ from dateutil.tz import tzutc
 import sqlalchemy as sa
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.sql.expression import true
-from sqlalchemy.orm.exc import MultipleResultsFound, NoResultFound
 
 from ai.backend.common.events import (
     AgentStartedEvent,


### PR DESCRIPTION
When loading the scheduler, it is to apply both the etcd setting and the current db setting.

this PR related to [#960](https://github.com/lablup/backend.ai-webui/issues/960) in webUI.