### PR TITLE
fix: do not collect data for utilization idle checker when interval is not passed

### DIFF
--- a/changes/441.fix
+++ b/changes/441.fix
@@ -1,0 +1,1 @@
+Do not collect the data for utilization idle checker when the current time does not exceed the sum of the last collect time and the interval of the checker.

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -421,13 +421,13 @@ class UtilizationIdleChecker(BaseIdleChecker):
         unavailable_resources: Set[str] = set()
 
         util_series_key = f"session.{session_id}.util_series"
-        util_last_updated_key = f"session.{session_id}.util_last_updated"
+        util_last_collected_key = f"session.{session_id}.util_last_collected"
 
         # Wait until the time "interval" is passed after the last udpated time.
         t = await self._redis.time()
-        raw_util_last_updated = await self._redis.get(util_last_updated_key)
-        util_last_updated = float(raw_util_last_updated) if raw_util_last_updated else 0
-        if t - util_last_updated < interval:
+        raw_util_last_collected = await self._redis.get(util_last_collected_key)
+        util_last_collected = float(raw_util_last_collected) if raw_util_last_collected else 0
+        if t - util_last_collected < interval:
             return True
 
         # Respect initial grace period (no termination of the session)
@@ -516,7 +516,7 @@ class UtilizationIdleChecker(BaseIdleChecker):
             expire=max(86400, int(self.time_window.total_seconds() * 2)),
         )
         await self._redis.set(
-            util_last_updated_key,
+            util_last_collected_key,
             f"{t:.06f}",
             expire=max(86400, int(self.time_window.total_seconds() * 2)),
         )

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -424,7 +424,6 @@ class UtilizationIdleChecker(BaseIdleChecker):
         util_last_updated_key = f"session.{session_id}.util_last_updated"
 
         # Wait until the time "interval" is passed after the last udpated time.
-        from icecream import ic
         t = await self._redis.time()
         raw_util_last_updated = await self._redis.get(util_last_updated_key)
         util_last_updated = float(raw_util_last_updated) if raw_util_last_updated else 0


### PR DESCRIPTION
This PR adds logic not to collect data points for utilization idle checker when the current time does not exceed the sum of the last collect time and the `interval` of the checker. Previously, each Manager process independently collects data without considering the interval, which results in a much faster session termination than intended. 

For example, the idle timeout is reduced by half if there are two Managers since they collect the data twice within the configured interval. By the same logic, if there are three Managers, the idle timeout is reduced by one-third.

So, this PR logs the last collect time and does not collect the data when the `interval` is not passed from it.