### PR TITLE
fix: Handle failure of advisory locks gracefully

### DIFF
--- a/changes/444.fix
+++ b/changes/444.fix
@@ -1,0 +1,1 @@
+Handle failure of acquiring postgres advisory locks in the scheduler gracefully, by translating them as logged cancellations


### PR DESCRIPTION
We are using PostgreSQL advisory locks to synchronize the scheduler invocation (both `PENDING` to `SCHEDULED` transition and `SCHEDULED` to `PENDING` transition).
The second transition usually takes more time due to agent RPC calls to create actual containers, and sometimes it results in database-level "lock not available" error (with `lock_timeout=30000` config).
Since the locking failure itself is not a bug, let's translate it to an informational log instead of alarming errors.
Though, we need to investigate potential deadlocks in the agent side if this happens frequently and repeatedly.