### PR TITLE
fix: Regression of batch-type sessions

### DIFF
--- a/changes/447.fix
+++ b/changes/447.fix
@@ -1,1 +1,1 @@
-Fix the regression of batch-type sessions by moving startup_command invocation to agents
+Fix the regression of batch-type sessions by moving `startup_command` invocation to agents

--- a/changes/447.fix
+++ b/changes/447.fix
@@ -1,0 +1,1 @@
+Fix the regression of batch-type sessions by moving startup_command invocation to agents

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -80,7 +80,6 @@ from ai.backend.common.types import (
     KernelId,
     ClusterMode,
     KernelEnqueueingConfig,
-    SessionId,
     SessionTypes,
     check_typed_dict,
 )
@@ -506,7 +505,6 @@ async def _create(request: web.Request, params: Any) -> web.Response:
             session_tag=params['tag'],
             starts_at=starts_at,
         ))
-        session_id = cast(SessionId, kernel_id)  # the main kernel's ID is the session ID
         resp['sessionId'] = str(kernel_id)  # changed since API v5
         resp['sessionName'] = str(params['session_name'])
         resp['status'] = 'PENDING'

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -74,7 +74,7 @@ from ai.backend.common.events import (
     SessionTerminatedEvent,
 )
 from ai.backend.common.logging import BraceStyleAdapter
-from ai.backend.common.utils import str_to_timedelta
+from ai.backend.common.utils import cancel_tasks, str_to_timedelta
 from ai.backend.common.types import (
     AgentId,
     KernelId,
@@ -552,8 +552,6 @@ async def _create(request: web.Request, params: Any) -> web.Response:
                         if 'allowed_envs' in item.keys():
                             response_dict['allowed_envs'] = item['allowed_envs']
                         resp['servicePorts'].append(response_dict)
-                    # TODO: handle shutdown of dangling tasks
-                    asyncio.create_task(root_ctx.registry.execute_batch(session_id))
                 else:
                     resp['status'] = row['status'].name
     except asyncio.CancelledError:
@@ -1027,8 +1025,6 @@ async def create_cluster(request: web.Request, params: Any) -> web.Response:
                         if 'allowed_envs' in item.keys():
                             response_dict['allowed_envs'] = item['allowed_envs']
                         resp['servicePorts'].append(response_dict)
-                    # TODO: handle shutdown of dangling tasks
-                    asyncio.create_task(root_ctx.registry.execute_batch(session_id))
                 else:
                     resp['status'] = row['status'].name
 
@@ -1962,13 +1958,7 @@ async def shutdown(app: web.Application) -> None:
     app_ctx.stats_task.cancel()
     await app_ctx.stats_task
 
-    for task in {*app_ctx.pending_waits}:
-        if not task.done():
-            task.cancel()
-            try:
-                await task
-            except asyncio.CancelledError:
-                pass
+    await cancel_tasks(app_ctx.pending_waits)
 
 
 def create_app(default_cors_options: CORSOptions) -> Tuple[web.Application, Iterable[WebMiddleware]]:


### PR DESCRIPTION
* It should be handled by the agent so that the execution should be
  triggered and continued regardless of the manager-side interrupts
  once the container creation succeeds in the agent.
