### PR TITLE
fix: Standard-compliant GQL endpoint

### DIFF
--- a/changes/448.fix
+++ b/changes/448.fix
@@ -1,0 +1,1 @@
+Add a new GQL endpoint `/admin/gql` (in addition to existing `/admin/graphql`) which uses the standard-compliant response format

--- a/src/ai/backend/manager/api/admin.py
+++ b/src/ai/backend/manager/api/admin.py
@@ -157,7 +157,6 @@ def create_app(default_cors_options: CORSOptions) -> Tuple[web.Application, Iter
     app = web.Application()
     app.on_startup.append(init)
     app.on_shutdown.append(shutdown)
-    app['api_versions'] = (2, 3, 4)
     app['admin.context'] = PrivateContext()
     cors = aiohttp_cors.setup(app, defaults=default_cors_options)
     cors.add(app.router.add_route('POST', r'/graphql', handle_gql_legacy))

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -104,6 +104,10 @@ VALID_VERSIONS: Final = frozenset([
 
     # rewrote vfolder upload/download APIs to migrate to external storage proxies
     'v6.20200815',
+
+    # added standard-compliant /admin/gql endpoint
+    # deprecated /admin/graphql endpoint
+    'v6.20210815',
 ])
 LATEST_REV_DATES: Final = {
     1: '20160915',
@@ -111,9 +115,9 @@ LATEST_REV_DATES: Final = {
     3: '20181215',
     4: '20190615',
     5: '20191215',
-    6: '20200815',
+    6: '20210815',
 }
-LATEST_API_VERSION: Final = 'v6.20200815'
+LATEST_API_VERSION: Final = 'v6.20210815'
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
 

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -220,7 +220,7 @@ async def exception_middleware(request: web.Request,
         await stats_monitor.report_metric(INCREMENT, 'ai.backend.manager.api.failures')
         await stats_monitor.report_metric(INCREMENT, f'ai.backend.manager.api.status.{ex.status_code}')
         if ex.status_code == 404:
-            raise GenericNotFound
+            raise GenericNotFound(f"Unknown URL path: {request.path}")
         if ex.status_code == 405:
             concrete_ex = cast(web.HTTPMethodNotAllowed, ex)
             raise MethodNotAllowed(concrete_ex.method, concrete_ex.allowed_methods)


### PR DESCRIPTION
- fix: Add a new GQL handler that speaks standard-compliant responses
- fix: Bump the API version to indicate existence of the new GQL endpoint
