### PR TITLE
feat: Add aiomonitor for manager

### DIFF
--- a/changes/450.feature
+++ b/changes/450.feature
@@ -1,0 +1,1 @@
+Add aiomonitor module for manager

--- a/setup.cfg
+++ b/setup.cfg
@@ -72,6 +72,7 @@ install_requires =
     PyJWT==1.7.1
     zipstream-new~=1.1.8
     lark-parser>=0.9.0
+    aiomonitor~=0.4.5
 zip_safe = false
 include_package_data = true
 

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -288,6 +288,7 @@ manager_local_config_iv = t.Dict({
         t.Key('hide-agents', default=False): t.Bool,
         t.Key('importer-image', default='lablup/importer:manylinux2010'): t.String,
         t.Key('max-wsmsg-size', default=16 * (2**20)): t.ToInt,  # default: 16 MiB
+        t.Key('aiomonitor-port', default=50001): t.Int,
     }).allow_extra('*'),
     t.Key('docker-registry'): t.Dict({  # deprecated in v20.09
         t.Key('ssl-verify', default=True): t.ToBool,

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -288,7 +288,7 @@ manager_local_config_iv = t.Dict({
         t.Key('hide-agents', default=False): t.Bool,
         t.Key('importer-image', default='lablup/importer:manylinux2010'): t.String,
         t.Key('max-wsmsg-size', default=16 * (2**20)): t.ToInt,  # default: 16 MiB
-        t.Key('aiomonitor-port', default=50001): t.Int,
+        t.Key('aiomonitor-port', default=50001): t.Int[1:65535],
     }).allow_extra('*'),
     t.Key('docker-registry'): t.Dict({  # deprecated in v20.09
         t.Key('ssl-verify', default=True): t.ToBool,

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -32,6 +32,7 @@ import click
 from pathlib import Path
 from setproctitle import setproctitle
 import sqlalchemy as sa
+import aiomonitor
 
 from ai.backend.common import redis
 from ai.backend.common.cli import LazyGroup
@@ -633,6 +634,13 @@ async def server_main(loop: asyncio.AbstractEventLoop,
                 str(root_ctx.local_config['manager']['ssl-cert']),
                 str(root_ctx.local_config['manager']['ssl-privkey']),
             )
+        
+        # Start aiomonitor.
+        # Port is set by config (default=50001).
+        m = aiomonitor.Monitor(loop, port=root_ctx.local_config['manager']['aiomonitor-port'])
+        m.prompt = "monitor (manager) >>> "
+        m.start()
+        
         runner = web.AppRunner(root_app)
         await runner.setup()
         service_addr = root_ctx.local_config['manager']['service-addr']
@@ -706,7 +714,6 @@ def main(ctx: click.Context, config_path: Path, debug: bool) -> None:
                 log.info('runtime: {0}', env_info())
                 log_config = logging.getLogger('ai.backend.manager.config')
                 log_config.debug('debug mode enabled.')
-
                 if cfg['manager']['event-loop'] == 'uvloop':
                     import uvloop
                     uvloop.install()

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -637,7 +637,7 @@ async def server_main(loop: asyncio.AbstractEventLoop,
 
         # Start aiomonitor.
         # Port is set by config (default=50001).
-        m = aiomonitor.Monitor(loop, port=root_ctx.local_config['manager']['aiomonitor-port'])
+        m = aiomonitor.Monitor(loop, port=root_ctx.local_config['manager']['aiomonitor-port'], console_enabled=False)
         m.prompt = "monitor (manager) >>> "
         m.start()
 
@@ -669,6 +669,7 @@ async def server_main(loop: asyncio.AbstractEventLoop,
         try:
             yield
         finally:
+            m.close()
             log.info('shutting down...')
             await runner.cleanup()
 

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -637,7 +637,11 @@ async def server_main(loop: asyncio.AbstractEventLoop,
 
         # Start aiomonitor.
         # Port is set by config (default=50001).
-        m = aiomonitor.Monitor(loop, port=root_ctx.local_config['manager']['aiomonitor-port'], console_enabled=False)
+        m = aiomonitor.Monitor(
+            loop,
+            port=root_ctx.local_config['manager']['aiomonitor-port'],
+            console_enabled=False
+        )
         m.prompt = "monitor (manager) >>> "
         m.start()
 

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -634,13 +634,13 @@ async def server_main(loop: asyncio.AbstractEventLoop,
                 str(root_ctx.local_config['manager']['ssl-cert']),
                 str(root_ctx.local_config['manager']['ssl-privkey']),
             )
-        
+
         # Start aiomonitor.
         # Port is set by config (default=50001).
         m = aiomonitor.Monitor(loop, port=root_ctx.local_config['manager']['aiomonitor-port'])
         m.prompt = "monitor (manager) >>> "
         m.start()
-        
+
         runner = web.AppRunner(root_app)
         await runner.setup()
         service_addr = root_ctx.local_config['manager']['service-addr']


### PR DESCRIPTION
This PR is started by https://op.lablup.ai/projects/backend-ai-server-and-sdk/work_packages/1414/

aiomonitor: https://github.com/aio-libs/aiomonitor
By using aiomonitor, you can monitoring asynchronous tasks and can execute some asynchronous commands in running application.

You can set port to connect with monitor by editing TOML configs.