### PR TITLE
fix: Apply dataloader batching to Group.scaling_groups

### DIFF
--- a/changes/451.fix
+++ b/changes/451.fix
@@ -1,0 +1,1 @@
+Apply missing batching of database queries for the `Group.scaling_groups` GraphQL field resolver.

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -876,7 +876,7 @@ class Queries(graphene.ObjectType):
     ) -> ScalingGroup:
         ctx: GraphQueryContext = info.context
         loader = ctx.dataloader_manager.get_loader(
-            ctx, 'ScalingGroup.by_name'
+            ctx, 'ScalingGroup.by_name',
         )
         return await loader.load(name)
 

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -159,9 +159,11 @@ class Group(graphene.ObjectType):
         )
 
     async def resolve_scaling_groups(self, info: graphene.ResolveInfo) -> Sequence[ScalingGroup]:
-        from .scaling_group import ScalingGroup
         graph_ctx: GraphQueryContext = info.context
-        sgroups = await ScalingGroup.load_by_group(graph_ctx, self.id)
+        loader = graph_ctx.dataloader_manager.get_loader(
+            graph_ctx, "ScalingGroup.by_group",
+        )
+        sgroups = await loader.load(self.id)
         return [sg.name for sg in sgroups]
 
     @classmethod

--- a/src/ai/backend/manager/models/scaling_group.py
+++ b/src/ai/backend/manager/models/scaling_group.py
@@ -23,6 +23,7 @@ from .base import (
     simple_db_mutate_returning_item,
     set_if_set,
     batch_result,
+    batch_multiresult,
 )
 from .group import resolve_group_name_or_id
 from .user import UserRole
@@ -263,7 +264,8 @@ class ScalingGroup(graphene.ObjectType):
     ) -> Sequence[ScalingGroup]:
         j = sa.join(
             scaling_groups, sgroups_for_keypairs,
-            scaling_groups.c.name == sgroups_for_keypairs.c.scaling_group)
+            scaling_groups.c.name == sgroups_for_keypairs.c.scaling_group
+        )
         query = (
             sa.select([scaling_groups])
             .select_from(j)
@@ -276,6 +278,27 @@ class ScalingGroup(graphene.ObjectType):
                 obj async for row in (await conn.stream(query))
                 if (obj := cls.from_row(ctx, row)) is not None
             ]
+
+    @classmethod
+    async def batch_load_by_group(
+        cls,
+        ctx: GraphQueryContext,
+        group_ids: Sequence[uuid.UUID],
+    ) -> Sequence[Sequence[ScalingGroup | None]]:
+        j = sa.join(
+            scaling_groups, sgroups_for_groups,
+            scaling_groups.c.name == sgroups_for_groups.c.scaling_group
+        )
+        query = (
+            sa.select([scaling_groups])
+            .select_from(j)
+            .where(sgroups_for_groups.c.group.in_(group_ids))
+        )
+        async with ctx.db.begin_readonly() as conn:
+            return await batch_multiresult(
+                ctx, conn, query, cls,
+                group_ids, lambda row: row['group'],
+            )
 
     @classmethod
     async def batch_load_by_name(


### PR DESCRIPTION
Without batching and with many number of projects, it may generate too many concurrent database connections at the same time when multiple `Group` GraphQL objects are queried with the `scaling_groups` field.
Let's apply the missing aiodataloader here.
