### PR TITLE
fix: Revamp user group GQL queries

### DIFF
--- a/changes/452.feature
+++ b/changes/452.feature
@@ -1,0 +1,1 @@
+Add `group_by_name` GraphQL query to directly get group(s) from the given name

--- a/changes/452.feature
+++ b/changes/452.feature
@@ -1,1 +1,1 @@
-Add `group_by_name` GraphQL query to directly get group(s) from the given name
+Add `groups_by_name` GraphQL query to directly get group(s) from the given name

--- a/changes/452.fix
+++ b/changes/452.fix
@@ -1,0 +1,1 @@
+Apply batching to user group resolution in GraphQL queries

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -248,7 +248,7 @@ class Queries(graphene.ObjectType):
     # Within a single domain, this will always return nothing or a single item,
     # but if queried across all domains by superadmins, it may return multiple results
     # because the group name is unique only inside each domain.
-    group_by_name = graphene.List(
+    groups_by_name = graphene.List(
         Group,
         name=graphene.String(required=True),
         domain_name=graphene.String(),
@@ -576,7 +576,7 @@ class Queries(graphene.ObjectType):
         return group
 
     @staticmethod
-    async def resolve_group_by_name(
+    async def resolve_groups_by_name(
         executor: AsyncioExecutor,
         info: graphene.ResolveInfo,
         name: str,

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -241,19 +241,24 @@ class Queries(graphene.ObjectType):
 
     group = graphene.Field(
         Group,
-        id=graphene.UUID(required=True))
+        id=graphene.UUID(required=True),
+        domain_name=graphene.String(),
+    )
 
     # Within a single domain, this will always return nothing or a single item,
     # but if queried across all domains by superadmins, it may return multiple results
     # because the group name is unique only inside each domain.
     group_by_name = graphene.List(
         Group,
-        name=graphene.String(required=True))
+        name=graphene.String(required=True),
+        domain_name=graphene.String(),
+    )
 
     groups = graphene.List(
         Group,
         domain_name=graphene.String(),
-        is_active=graphene.Boolean())
+        is_active=graphene.Boolean(),
+    )
 
     image = graphene.Field(
         Image,

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -36,6 +36,7 @@ from .base import (
     simple_db_mutate,
     simple_db_mutate_returning_item,
     batch_result,
+    batch_multiresult,
 )
 from .storage import StorageSessionManager
 from .user import ModifyUserInput, UserRole
@@ -195,7 +196,7 @@ class Group(graphene.ObjectType):
         group_ids: Sequence[uuid.UUID],
         *,
         domain_name: str = None
-    ) -> Sequence[Optional[Group]]:
+    ) -> Sequence[Group | None]:
         query = (
             sa.select([groups])
             .select_from(groups)
@@ -207,6 +208,48 @@ class Group(graphene.ObjectType):
             return await batch_result(
                 graph_ctx, conn, query, cls,
                 group_ids, lambda row: row['id'],
+            )
+
+    @classmethod
+    async def batch_load_by_name(
+        cls,
+        graph_ctx: GraphQueryContext,
+        group_names: Sequence[str],
+        *,
+        domain_name: str = None
+    ) -> Sequence[Sequence[Group | None]]:
+        query = (
+            sa.select([groups])
+            .select_from(groups)
+            .where(groups.c.name.in_(group_names))
+        )
+        if domain_name is not None:
+            query = query.where(groups.c.domain_name == domain_name)
+        async with graph_ctx.db.begin_readonly() as conn:
+            return await batch_multiresult(
+                graph_ctx, conn, query, cls,
+                group_names, lambda row: row['name'],
+            )
+
+    @classmethod
+    async def batch_load_by_user(
+        cls,
+        graph_ctx: GraphQueryContext,
+        user_ids: Sequence[uuid.UUID],
+    ) -> Sequence[Sequence[Group | None]]:
+        j = sa.join(
+            groups, association_groups_users,
+            groups.c.id == association_groups_users.c.group_id,
+        )
+        query = (
+            sa.select([groups])
+            .select_from(j)
+            .where(association_groups_users.c.user_id.in_(user_ids))
+        )
+        async with graph_ctx.db.begin_readonly() as conn:
+            return await batch_multiresult(
+                graph_ctx, conn, query, cls,
+                user_ids, lambda row: row['user_id'],
             )
 
     @classmethod


### PR DESCRIPTION
* Add "group_by_name" query to get group(s) from their names.
* Remove potential spikes of concurrent transactions when querying
  groups associated with specific users.
