### PR TITLE
feat: add lock-related DB connection settings

### DIFF
--- a/changes/454.feature
+++ b/changes/454.feature
@@ -1,0 +1,1 @@
+Add lock-related DB connection settings for better DB stability when the Manager does not release a lock and/or idle for a long time after acquiring a lock.

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -83,7 +83,12 @@ convention = {
 metadata = sa.MetaData(naming_convention=convention)
 
 pgsql_connect_opts = {
-    'server_settings': {'jit': 'off'}
+    'server_settings': {
+        'jit': 'off',
+        'deadlock_timeout': '10s',
+        'lock_timeout': '3000',
+        'idle_in_transaction_session_timeout': '60000',
+    },
 }
 
 


### PR DESCRIPTION
Add lock-related DB connection settings for better DB stability when the Manager does not release a lock and/or idle for a long time after acquiring a lock.