### PR TITLE
fix: Regression of session concurrency limit checks

### DIFF
--- a/changes/455.fix
+++ b/changes/455.fix
@@ -1,0 +1,1 @@
+Fix a regression of session concurrency limit checks due to transaction retry refactoring in #429

--- a/src/ai/backend/manager/scheduler/predicates.py
+++ b/src/ai/backend/manager/scheduler/predicates.py
@@ -58,7 +58,7 @@ async def check_concurrency(
     sess_ctx: PendingSession,
 ) -> PredicateResult:
 
-    async def _check():
+    async def _check() -> PredicateResult:
         async with db_conn.begin_nested():
             select_query = (
                 sa.select([keypair_resource_policies])
@@ -93,9 +93,9 @@ async def check_concurrency(
                 .where(keypairs.c.access_key == sess_ctx.access_key)
             )
             await db_conn.execute(update_query)
+            return PredicateResult(True)
 
-    await execute_with_retry(_check)
-    return PredicateResult(True)
+    return await execute_with_retry(_check)
 
 
 async def check_dependencies(


### PR DESCRIPTION
* There was a mistake while introducing DB transaction retries.
