### PR TITLE
fix: A hidden bug in the new batched resolvers for Group and ScalingGroup

### DIFF
--- a/changes/457.fix
+++ b/changes/457.fix
@@ -1,0 +1,1 @@
+Fix a critical bug due to a missing column from the select targets of join SQL queries in the new batched GQL object resolvers for `Group.by_user` and `ScalingGroup.by_group`, which only happens with non-admin user accounts

--- a/src/ai/backend/manager/models/group.py
+++ b/src/ai/backend/manager/models/group.py
@@ -242,7 +242,7 @@ class Group(graphene.ObjectType):
             groups.c.id == association_groups_users.c.group_id,
         )
         query = (
-            sa.select([groups])
+            sa.select([groups, association_groups_users.c.user_id])
             .select_from(j)
             .where(association_groups_users.c.user_id.in_(user_ids))
         )

--- a/src/ai/backend/manager/models/scaling_group.py
+++ b/src/ai/backend/manager/models/scaling_group.py
@@ -290,7 +290,7 @@ class ScalingGroup(graphene.ObjectType):
             scaling_groups.c.name == sgroups_for_groups.c.scaling_group
         )
         query = (
-            sa.select([scaling_groups])
+            sa.select([scaling_groups, sgroups_for_groups.c.group])
             .select_from(j)
             .where(sgroups_for_groups.c.group.in_(group_ids))
         )


### PR DESCRIPTION
* When fetching from a joined query and wanting to aggregate the rows by
  the key only present in a joined source table, the column must be explicitly
  selected in the base query.
