### PR TITLE
fix: Let the timeout idle checker skip batch-type sessions

### DIFF
--- a/changes/460.fix
+++ b/changes/460.fix
@@ -1,0 +1,1 @@
+Let the idle timeout checkr skip batch-type sessions as they do not have any interaction whose absence are translated to idleness

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -45,7 +45,7 @@ from ai.backend.common.events import (
     SessionStartedEvent,
 )
 from ai.backend.common.logging import BraceStyleAdapter
-from ai.backend.common.types import AccessKey, aobject
+from ai.backend.common.types import AccessKey, aobject, SessionTypes
 from ai.backend.common.utils import nmget
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
@@ -280,6 +280,8 @@ class TimeoutIdleChecker(BaseIdleChecker):
 
     async def check_session(self, session: Row, dbconn: SAConnection) -> bool:
         session_id = session["id"]
+        if session["session_type"] == SessionTypes.BATCH:
+            return True
         active_streams = await self._redis.zcount(
             f"session.{session_id}.active_app_connections"
         )


### PR DESCRIPTION
* Batch type sessions inherently do not have any interaction,
  which is the criteria for idle timeout.
