### PR TITLE
fix: Fix duplicate codes and add duplicate target dir check for `mount_map` when creating sessions

### DIFF
--- a/changes/461.fix
+++ b/changes/461.fix
@@ -1,0 +1,1 @@
+Remove duplicate codes of `mount_map` check and add alias name check for `mount_map`.

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -391,14 +391,22 @@ async def _create(request: web.Request, params: Any) -> web.Response:
 
     # Check work directory and reserved name directory.
     mount_map = params['config'].get('mount_map')
+    log.debug("<#$%> Mount Map: {0}", mount_map)
     if mount_map is not None:
-        for p in mount_map.values():
+        original_folders = mount_map.keys()
+        alias_folders = mount_map.values()
+        if len(alias_folders) != len(set(alias_folders)):
+            raise InvalidAPIParameters(f'Duplicate alias folder name exists.')
+        for p in alias_folders:
+            alias_name = p.replace('/home/work/', '')
             if p is None:
                 continue
             if not p.startswith('/home/work/'):
                 raise InvalidAPIParameters(f'Path {p} should start with /home/work/')
-            if p is not None and not verify_vfolder_name(p.replace('/home/work/', '')):
+            if p is not None and not verify_vfolder_name(alias_name):
                 raise InvalidAPIParameters(f'Path {str(p)} is reserved for internal operations.')
+            if alias_name in original_folders:
+                raise InvalidAPIParameters(f'Alias name cannot be set to an existing folder name: {alias_name}')
 
     # Resolve the image reference.
     try:

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -389,15 +389,7 @@ async def _create(request: web.Request, params: Any) -> web.Response:
     current_task = asyncio.current_task()
     assert current_task is not None
 
-    if mount_map := params['config'].get('mount_map'):
-        for p in mount_map.values():
-            if p is None:
-                continue
-            if not p.startswith('/home/work/'):
-                raise InvalidAPIParameters(f'Path {p} should start with /home/work/')
-            if p is not None and not verify_vfolder_name(p.replace('/home/work/', '')):
-                raise InvalidAPIParameters(f'Path {str(p)} is reserved for internal operations.')
-
+    # Check work directory and reserved name directory.
     mount_map = params['config'].get('mount_map')
     if mount_map is not None:
         for p in mount_map.values():

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -405,7 +405,8 @@ async def _create(request: web.Request, params: Any) -> web.Response:
             if p is not None and not verify_vfolder_name(alias_name):
                 raise InvalidAPIParameters(f'Path {str(p)} is reserved for internal operations.')
             if alias_name in original_folders:
-                raise InvalidAPIParameters(f'Alias name cannot be set to an existing folder name: {alias_name}')
+                raise InvalidAPIParameters('Alias name cannot be set to an existing folder name: ' \
+                    + str(alias_name))
             if alias_name == '':
                 raise InvalidAPIParameters('Alias name cannot be empty.')
 

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -405,8 +405,8 @@ async def _create(request: web.Request, params: Any) -> web.Response:
             if p is not None and not verify_vfolder_name(alias_name):
                 raise InvalidAPIParameters(f'Path {str(p)} is reserved for internal operations.')
             if alias_name in original_folders:
-                raise InvalidAPIParameters('Alias name cannot be set to an existing folder name: ' \
-                    + str(alias_name))
+                raise InvalidAPIParameters('Alias name cannot be set to an existing folder name: '
+                                            + str(alias_name))
             if alias_name == '':
                 raise InvalidAPIParameters('Alias name cannot be empty.')
 

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -391,7 +391,6 @@ async def _create(request: web.Request, params: Any) -> web.Response:
 
     # Check work directory and reserved name directory.
     mount_map = params['config'].get('mount_map')
-    log.debug("<#$%> Mount Map: {0}", mount_map)
     if mount_map is not None:
         original_folders = mount_map.keys()
         alias_folders = mount_map.values()

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -395,7 +395,7 @@ async def _create(request: web.Request, params: Any) -> web.Response:
         original_folders = mount_map.keys()
         alias_folders = mount_map.values()
         if len(alias_folders) != len(set(alias_folders)):
-            raise InvalidAPIParameters(f'Duplicate alias folder name exists.')
+            raise InvalidAPIParameters('Duplicate alias folder name exists.')
         for p in alias_folders:
             alias_name = p.replace('/home/work/', '')
             if p is None:

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -407,6 +407,8 @@ async def _create(request: web.Request, params: Any) -> web.Response:
                 raise InvalidAPIParameters(f'Path {str(p)} is reserved for internal operations.')
             if alias_name in original_folders:
                 raise InvalidAPIParameters(f'Alias name cannot be set to an existing folder name: {alias_name}')
+            if alias_name == '':
+                raise InvalidAPIParameters('Alias name cannot be empty.')
 
     # Resolve the image reference.
     try:


### PR DESCRIPTION
Internal Ticket: OP#1432
This PR removes:
* Duplicate codes of checking the validity of `mount_map` argument.

This PR adds:
* Check duplicate alias folder name.
* Check existing folder name as alias name.
* Check empty alias name.