### PR TITLE
feat: Add Etcd option to set MTU for the overlay networks of a cluster session

### DIFF
--- a/changes/475.feature
+++ b/changes/475.feature
@@ -1,0 +1,1 @@
+Add an Etcd option to set MTU in creating an overlay network for a cluster session to support improved performance for multi-node cluster training.

--- a/config/sample.etcd.config.json
+++ b/config/sample.etcd.config.json
@@ -13,6 +13,9 @@
         "type": "harbor2",
         "project": "stable,ngc"
       }
+    },
+    "network": {
+      "mtu": 1500
     }
   },
   "idle": {
@@ -40,7 +43,7 @@
     },
     "scheduler": {
       "fifo": {
-        "num_retries_to_skip": 3,
+        "num_retries_to_skip": 3
       }
     }
   }

--- a/config/sample.etcd.config.json
+++ b/config/sample.etcd.config.json
@@ -13,9 +13,6 @@
         "type": "harbor2",
         "project": "stable,ngc"
       }
-    },
-    "network": {
-      "mtu": 1500
     }
   },
   "idle": {
@@ -31,6 +28,9 @@
     "subnet": {
       "agent": "0.0.0.0/0",
       "container": "0.0.0.0/0"
+    },
+    "overlay": {
+      "mtu": 1500
     }
   },
   "watcher": {

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -59,7 +59,7 @@ Alias keys are also URL-quoted in the same way.
            - type: "docker" | "harbor" | "harbor2"
            - project: "project1-name,project2-name,..."  # harbor only
            - ssl-verify: "yes" | "no"
-         ...           
+         ...
      + redis
        - addr: "{redis-host}:{redis-port}"
        - password: {password}
@@ -113,7 +113,7 @@ Alias keys are also URL-quoted in the same way.
        + subnet
          - agent: "0.0.0.0/0"
          - container: "0.0.0.0/0"
-       + overlay 
+       + overlay
          - mtu: 1500  # Maximum Transmission Unit
      + watcher
        - token: {some-secret}

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -59,9 +59,7 @@ Alias keys are also URL-quoted in the same way.
            - type: "docker" | "harbor" | "harbor2"
            - project: "project1-name,project2-name,..."  # harbor only
            - ssl-verify: "yes" | "no"
-         ...
-       + network
-           - mtu: 1500  # Maximum Transmission Unit
+         ...           
      + redis
        - addr: "{redis-host}:{redis-port}"
        - password: {password}
@@ -115,6 +113,8 @@ Alias keys are also URL-quoted in the same way.
        + subnet
          - agent: "0.0.0.0/0"
          - container: "0.0.0.0/0"
+       + overlay 
+         - mtu: 1500  # Maximum Transmission Unit
      + watcher
        - token: {some-secret}
    + volumes
@@ -351,9 +351,6 @@ shared_config_iv = t.Dict({
     }).allow_extra('*'),
     t.Key('docker'): t.Dict({
         t.Key('registry'): t.Mapping(t.String, container_registry_iv),
-        t.Key('network', default=None): t.Null | t.Dict({
-            t.Key('mtu', default=1500): t.Int[1:],
-        }).allow_extra('*'),
     }).allow_extra('*'),
     t.Key('plugins', default=_shdefs['plugins']): t.Dict({
         t.Key('accelerator', default=_shdefs['plugins']['accelerator']):
@@ -365,6 +362,9 @@ shared_config_iv = t.Dict({
         t.Key('subnet', default=_shdefs['network']['subnet']): t.Dict({
             t.Key('agent', default=_shdefs['network']['subnet']['agent']): tx.IPNetwork,
             t.Key('container', default=_shdefs['network']['subnet']['container']): tx.IPNetwork,
+        }).allow_extra('*'),
+        t.Key('overlay', default=None): t.Null | t.Dict({
+            t.Key('mtu', default=1500): t.Int[1:],
         }).allow_extra('*'),
     }).allow_extra('*'),
     t.Key('watcher', default=_shdefs['watcher']): t.Dict({

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -60,6 +60,8 @@ Alias keys are also URL-quoted in the same way.
            - project: "project1-name,project2-name,..."  # harbor only
            - ssl-verify: "yes" | "no"
          ...
+       + network
+           - mtu: "1500"
      + redis
        - addr: "{redis-host}:{redis-port}"
        - password: {password}
@@ -259,6 +261,7 @@ shared_config_defaults = {
     'volumes/_fsprefix': '/',
     'config/api/allow-origins': '*',
     'config/docker/image/auto_pull': 'digest',
+    'config/docker/network/mtu': '1500',
 }
 
 current_vfolder_types: ContextVar[List[str]] = ContextVar('current_vfolder_types')

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -61,7 +61,7 @@ Alias keys are also URL-quoted in the same way.
            - ssl-verify: "yes" | "no"
          ...
        + network
-           - mtu: "1500"
+           - mtu: 1500  # Maximum Transmission Unit
      + redis
        - addr: "{redis-host}:{redis-port}"
        - password: {password}
@@ -261,7 +261,6 @@ shared_config_defaults = {
     'volumes/_fsprefix': '/',
     'config/api/allow-origins': '*',
     'config/docker/image/auto_pull': 'digest',
-    'config/docker/network/mtu': '1500',
 }
 
 current_vfolder_types: ContextVar[List[str]] = ContextVar('current_vfolder_types')
@@ -352,6 +351,9 @@ shared_config_iv = t.Dict({
     }).allow_extra('*'),
     t.Key('docker'): t.Dict({
         t.Key('registry'): t.Mapping(t.String, container_registry_iv),
+        t.Key('network', default=None): t.Null | t.Dict({
+            t.Key('mtu', default=1500): t.Int[1:],
+        }).allow_extra('*'),
     }).allow_extra('*'),
     t.Key('plugins', default=_shdefs['plugins']): t.Dict({
         t.Key('accelerator', default=_shdefs['plugins']['accelerator']):

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1174,7 +1174,7 @@ class AgentRegistry:
         elif scheduled_session.cluster_mode == ClusterMode.MULTI_NODE:
             # Create overlay network for multi-node sessions
             network_name = f'bai-multinode-{scheduled_session.session_id}'
-            mtu = await self.shared_config.get_raw('config/docker/network/mtu')
+            mtu = await self.shared_config.get_raw('config/network/overlay/mtu')
             try:
                 # Overlay networks can only be created at the Swarm manager.
                 create_options = {

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1177,17 +1177,18 @@ class AgentRegistry:
             mtu = await self.shared_config.get_raw('config/docker/network/mtu')
             try:
                 # Overlay networks can only be created at the Swarm manager.
-                await self.docker.networks.create({
+                create_options = {
                     'Name': network_name,
                     'Driver': 'overlay',
                     'Attachable': True,
                     'Labels': {
                         'ai.backend.cluster-network': '1'
                     },
-                    'Options': {
-                        'com.docker.network.driver.mtu': mtu
-                    }
-                })
+                    'Options': {}
+                }
+                if mtu:
+                    create_options['Options']['com.docker.network.driver.mtu'] = mtu
+                await self.docker.networks.create(create_options)
             except Exception:
                 log.exception(f"Failed to create an overlay network {network_name}")
                 raise

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1187,7 +1187,7 @@ class AgentRegistry:
                     'Options': {}
                 }
                 if mtu:
-                    create_options['Options']['com.docker.network.driver.mtu'] = mtu
+                    create_options['Options'] = {'com.docker.network.driver.mtu': mtu}
                 await self.docker.networks.create(create_options)
             except Exception:
                 log.exception(f"Failed to create an overlay network {network_name}")

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1174,6 +1174,7 @@ class AgentRegistry:
         elif scheduled_session.cluster_mode == ClusterMode.MULTI_NODE:
             # Create overlay network for multi-node sessions
             network_name = f'bai-multinode-{scheduled_session.session_id}'
+            mtu = await self.shared_config.get_raw('config/docker/network/mtu')
             try:
                 # Overlay networks can only be created at the Swarm manager.
                 await self.docker.networks.create({
@@ -1182,6 +1183,9 @@ class AgentRegistry:
                     'Attachable': True,
                     'Labels': {
                         'ai.backend.cluster-network': '1'
+                    },
+                    'Options': {
+                        'com.docker.network.driver.mtu': mtu
                     }
                 })
             except Exception:


### PR DESCRIPTION
Add an Etcd option to set MTU in creating an overlay network for a cluster session to support improved performance for multi-node cluster training.

Internal Ticket: OP#1458
Related PR: [webui#1120](https://github.com/lablup/backend.ai-webui/pull/1120)