### PR TITLE
feat: Select and update kernel-pull-progress

### DIFF
--- a/src/ai/backend/manager/api/events.py
+++ b/src/ai/backend/manager/api/events.py
@@ -25,6 +25,7 @@ import trafaret as t
 
 from ai.backend.common import validators as tx
 from ai.backend.common.events import (
+    KernelPullProgressEvent,
     BgtaskCancelledEvent,
     BgtaskDoneEvent,
     BgtaskFailedEvent,
@@ -49,6 +50,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import AgentId
 
 from ..models import kernels, groups, UserRole
+from ..models.utils import execute_with_retry
 from ..types import Sentinel
 from .auth import auth_required
 from .exceptions import GenericNotFound, GenericForbidden, GroupNotFound
@@ -421,6 +423,24 @@ async def enqueue_bgtask_status_update(
     for q in app_ctx.task_update_queues:
         q.put_nowait(event)
 
+
+async def kernel_pull_progress_update(
+    app: web.Application,
+    source: AgentId,
+    event: KernelPullProgressEvent
+    ) -> None:
+    root_ctx: RootContext = app['_root.context']
+    app_ctx: PrivateContext = app['events.context']
+
+    async def _update() -> None:
+        async with root_ctx.db.begin() as conn:
+            query = sa.update(kernels).values({
+                'current_progress': event.current_progress,
+                'total_progress': event.total_progress,
+            }).where(kernels.c.id == event.kernel_id)
+
+            await conn.execute(query)
+    await execute_with_retry(_update)
 
 @attr.s(slots=True, auto_attribs=True, init=False)
 class PrivateContext:

--- a/src/ai/backend/manager/models/alembic/versions/48389041a712_add_kernel_pull_progress.py
+++ b/src/ai/backend/manager/models/alembic/versions/48389041a712_add_kernel_pull_progress.py
@@ -1,0 +1,26 @@
+"""add kernel pull progress
+
+Revision ID: 48389041a712
+Revises: 8679d0a7e22b
+Create Date: 2021-08-30 19:38:08.974019
+
+"""
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision = '48389041a712'
+down_revision = '8679d0a7e22b'
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.add_column('kernels', sa.Column('current_progress', sa.Integer, default=0))
+    op.add_column('kernels', sa.Column('total_progress', sa.Integer, default=0))
+    pass
+
+
+def downgrade():
+    pass

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -273,6 +273,10 @@ kernels = sa.Table(
              postgresql_where=sa.text(
                  "status NOT IN ('TERMINATED', 'CANCELLED') and "
                  "cluster_role = 'main'")),
+    
+    # progress
+    sa.Column('current_progress', sa.Integer(), default=0),
+    sa.Column('total_progress', sa.Integer(), default=0)
 )
 
 session_dependencies = sa.Table(
@@ -824,6 +828,7 @@ class ComputeSession(graphene.ObjectType):
 
             # statistics
             'num_queries': row['num_queries'],
+
         }
 
     @classmethod


### PR DESCRIPTION
[backend.ai-issue#227](https://github.com/lablup/backend.ai/issues/227)

- Manager Task
 
  - [x]  Spawn a background task when creating a new session, returning the task ID to the client after max_wait seconds.
  - [x] Let the background task relay the kernel_pull_progress events.

- About Background-Task
The bgtask contains asynchronous functions that select progress status from kernels table or update one on it. To ensure synchronization, I use ###Asyncio-lock. UpdateKernelpullprogress function that update progress status on 'kernels' table is responsible for KernelPullprogress Event. And, [Progress Reporter](https://github.com/lablup/backend.ai-manager/blob/85fe578508ad2edb6cd44587b607157a8d43ae76/src/ai/backend/manager/background.py#L38) is updated by the function. So, manager send the progress-reporter to client, and, client display kernel-pull-progress using the reporter.