### PR TITLE
fix: Improve advisory locks (follow-up to #482)

### DIFF
--- a/changes/483.fix
+++ b/changes/483.fix
@@ -1,0 +1,1 @@
+A follow-up fix for #482 to silence bogus DB API error upon service shutdown

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -123,7 +123,7 @@ def create_async_engine(*args, **kwargs) -> ExtendedAsyncSAEngine:
 
 
 @actxmgr
-async def create_database(
+async def connect_database(
     local_config: LocalConfig | Mapping[str, Any],
 ) -> AsyncIterator[ExtendedAsyncSAEngine]:
     from .base import pgsql_connect_opts

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -105,7 +105,7 @@ class ExtendedAsyncSAEngine(SAEngine):
             except sa.exc.DBAPIError as e:
                 if getattr(e.orig, 'pgcode', None) == '55P03':  # lock not available error
                     # This may happen upon shutdown after some time.
-                    return
+                    raise asyncio.CancelledError()
                 raise
             except asyncio.CancelledError:
                 raise

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -70,7 +70,7 @@ from .defs import REDIS_STAT_DB, REDIS_LIVE_DB, REDIS_IMAGE_DB, REDIS_STREAM_DB
 from .exceptions import InvalidArgument
 from .idle import create_idle_checkers
 from .models.storage import StorageSessionManager
-from .models.utils import ExtendedAsyncSAEngine, create_database
+from .models.utils import create_database
 from .plugin.webapp import WebappPluginContext
 from .registry import AgentRegistry
 from .scheduler.dispatcher import SchedulerDispatcher

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -70,7 +70,7 @@ from .defs import REDIS_STAT_DB, REDIS_LIVE_DB, REDIS_IMAGE_DB, REDIS_STREAM_DB
 from .exceptions import InvalidArgument
 from .idle import create_idle_checkers
 from .models.storage import StorageSessionManager
-from .models.utils import create_database
+from .models.utils import connect_database
 from .plugin.webapp import WebappPluginContext
 from .registry import AgentRegistry
 from .scheduler.dispatcher import SchedulerDispatcher
@@ -322,7 +322,7 @@ async def redis_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
 
 @aiotools.actxmgr
 async def database_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
-    async with create_database(root_ctx.local_config) as db:
+    async with connect_database(root_ctx.local_config) as db:
         root_ctx.db = db
         yield
 

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -4,7 +4,6 @@ import asyncio
 from datetime import datetime
 import functools
 import importlib
-import json
 import logging
 import os
 import pwd, grp
@@ -22,7 +21,6 @@ from typing import (
     Sequence,
     cast,
 )
-from urllib.parse import quote_plus as urlquote
 
 from aiohttp import web
 import aiohttp_cors
@@ -31,14 +29,12 @@ import aiotools
 import click
 from pathlib import Path
 from setproctitle import setproctitle
-import sqlalchemy as sa
 import aiomonitor
 
 from ai.backend.common import redis
 from ai.backend.common.cli import LazyGroup
 from ai.backend.common.events import EventDispatcher, EventProducer
 from ai.backend.common.utils import env_info, current_loop
-from ai.backend.common.json import ExtendedJSONEncoder
 from ai.backend.common.logging import Logger, BraceStyleAdapter
 from ai.backend.common.plugin.hook import HookPluginContext, ALL_COMPLETED, PASSED
 from ai.backend.common.plugin.monitor import (
@@ -73,9 +69,8 @@ from .config import (
 from .defs import REDIS_STAT_DB, REDIS_LIVE_DB, REDIS_IMAGE_DB, REDIS_STREAM_DB
 from .exceptions import InvalidArgument
 from .idle import create_idle_checkers
-from .models.base import pgsql_connect_opts
 from .models.storage import StorageSessionManager
-from .models.utils import create_async_engine
+from .models.utils import ExtendedAsyncSAEngine, create_database
 from .plugin.webapp import WebappPluginContext
 from .registry import AgentRegistry
 from .scheduler.dispatcher import SchedulerDispatcher
@@ -327,31 +322,9 @@ async def redis_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
 
 @aiotools.actxmgr
 async def database_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
-    username = root_ctx.local_config['db']['user']
-    password = root_ctx.local_config['db']['password']
-    address = root_ctx.local_config['db']['addr']
-    dbname = root_ctx.local_config['db']['name']
-    url = f"postgresql+asyncpg://{urlquote(username)}:{urlquote(password)}@{address}/{urlquote(dbname)}"
-
-    version_check_db = create_async_engine(url)
-    async with version_check_db.begin() as conn:
-        result = await conn.execute(sa.text("show server_version"))
-        major, minor, *_ = map(int, result.scalar().split("."))
-        if (major, minor) < (11, 0):
-            pgsql_connect_opts['server_settings'].pop("jit")
-    await version_check_db.dispose()
-
-    root_ctx.db = create_async_engine(
-        url,
-        connect_args=pgsql_connect_opts,
-        pool_size=8,
-        max_overflow=64,
-        json_serializer=functools.partial(json.dumps, cls=ExtendedJSONEncoder),
-        isolation_level="SERIALIZABLE",
-        future=True,
-    )
-    yield
-    await root_ctx.db.dispose()
+    async with create_database(root_ctx.local_config) as db:
+        root_ctx.db = db
+        yield
 
 
 @aiotools.actxmgr

--- a/tests/api/test_auth.py
+++ b/tests/api/test_auth.py
@@ -10,6 +10,7 @@ from ai.backend.manager.api.auth import _extract_auth_params, check_date
 from ai.backend.manager.api.exceptions import InvalidAuthParameters
 from ai.backend.manager.server import (
     database_ctx,
+    event_dispatcher_ctx,
     hook_plugin_ctx,
     monitoring_ctx,
     redis_ctx,
@@ -90,7 +91,14 @@ def test_check_date():
 async def test_authorize(etcd_fixture, database_fixture, create_app_and_client, get_headers):
     # The auth module requires config_server and database to be set up.
     app, client = await create_app_and_client(
-        [shared_config_ctx, redis_ctx, database_ctx, monitoring_ctx, hook_plugin_ctx],
+        [
+            shared_config_ctx,
+            redis_ctx,
+            event_dispatcher_ctx,
+            database_ctx,
+            monitoring_ctx,
+            hook_plugin_ctx,
+        ],
         ['.auth'])
 
     async def do_authorize(hash_type, api_version):

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -46,7 +46,7 @@ from ai.backend.manager.models import (
     agents,
     kernels, keypairs, vfolders,
 )
-from ai.backend.manager.models.utils import create_database
+from ai.backend.manager.models.utils import connect_database
 
 here = Path(__file__).parent
 
@@ -231,7 +231,7 @@ def database(request, local_config, test_db):
 
 @pytest.fixture()
 async def database_engine(local_config, database):
-    async with create_database(local_config) as db:
+    async with connect_database(local_config) as db:
         yield db
 
 

--- a/tests/test_advisory_lock.py
+++ b/tests/test_advisory_lock.py
@@ -37,7 +37,6 @@ async def test_lock(database_engine: ExtendedAsyncSAEngine) -> None:
         )
         rows = result.fetchall()
         print(rows)
-        assert len(rows) == 5
         result = await conn.exec_driver_sql(
             "SELECT objid, granted FROM pg_locks "
             "WHERE locktype = 'advisory' AND objid = 42 AND granted = 't';"

--- a/tests/test_advisory_lock.py
+++ b/tests/test_advisory_lock.py
@@ -17,9 +17,6 @@ async def test_lock(database_engine: ExtendedAsyncSAEngine) -> None:
             enter_count += 1
             await asyncio.sleep(1.0)
 
-    async with database_engine.connect() as conn:
-        await conn.exec_driver_sql("SELECT pg_advisory_unlock_all()")
-
     tasks = []
     for idx in range(5):
         tasks.append(

--- a/tests/test_distributed.py
+++ b/tests/test_distributed.py
@@ -19,7 +19,7 @@ from ai.backend.common.events import AbstractEvent, EventDispatcher, EventProduc
 
 from ai.backend.manager.defs import REDIS_STREAM_DB, AdvisoryLock
 from ai.backend.manager.distributed import GlobalTimer
-from ai.backend.manager.models.utils import create_database
+from ai.backend.manager.models.utils import connect_database
 
 if TYPE_CHECKING:
     from ai.backend.common.types import AgentId
@@ -95,7 +95,7 @@ class TimerNode(threading.Thread):
         event_producer = await EventProducer.new(redis_connector)
         event_dispatcher.consume(NoopEvent, None, _tick)
 
-        async with create_database(self.local_config) as db:
+        async with connect_database(self.local_config) as db:
             timer = GlobalTimer(
                 db,
                 AdvisoryLock.LOCKID_TEST,


### PR DESCRIPTION
This is a follow-up of #482.

* Handle "lock not available" error upon shutdown.
* Use non-blocking `pg_try_advisory_lock()` instead of blocking `pg_advisory_lock()` to avoid conflicts with statement/lock timeout configurations.
  - This incurs a slightly more CPU usage due to polling, but it will keep the DB client connection to be alive.
* refactor: Single-source database connection routines as `models.utils.connect_database()` async context manager.