### PR TITLE
feat: Allow config of RPC keepalive timeout via etcd

### DIFF
--- a/changes/485.feature
+++ b/changes/485.feature
@@ -1,0 +1,1 @@
+Allow configuration of the TCP keepalive timeout for the manager-to-agent RPC layer via etcd

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -116,7 +116,7 @@ Alias keys are also URL-quoted in the same way.
        + overlay
          - mtu: 1500  # Maximum Transmission Unit
        + rpc
-         - keepalive_timeout: 60  # seconds
+         - keepalive-timeout: 60  # seconds
      + watcher
        - token: {some-secret}
    + volumes

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -115,6 +115,8 @@ Alias keys are also URL-quoted in the same way.
          - container: "0.0.0.0/0"
        + overlay
          - mtu: 1500  # Maximum Transmission Unit
+       + rpc
+         - keepalive_timeout: 60  # seconds
      + watcher
        - token: {some-secret}
    + volumes

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -182,19 +182,30 @@ class PeerInvoker(Peer):
 
 
 @aiotools.actxmgr
-async def RPCContext(agent_id, addr, timeout=None, *, order_key: str = None):
+async def RPCContext(
+    agent_id: AgentId,
+    addr,
+    *,
+    invoke_timeout: float = None,
+    order_key: str = None,
+    keepalive_timeout: int = 60,
+) -> AsyncIterator[PeerInvoker]:
     global agent_peers
     peer = agent_peers.get(addr, None)
     if peer is None:
+        keepalive_retry_count = 3
+        keepalive_interval = keepalive_timeout // keepalive_retry_count
+        if keepalive_interval < 2:
+            keepalive_interval = 2
         peer = PeerInvoker(
             connect=ZeroMQAddress(addr),
             transport=ZeroMQRPCTransport,
             transport_opts={
                 'zsock_opts': {
                     zmq.TCP_KEEPALIVE: 1,
-                    zmq.TCP_KEEPALIVE_IDLE: 20,
-                    zmq.TCP_KEEPALIVE_INTVL: 5,
-                    zmq.TCP_KEEPALIVE_CNT: 3,
+                    zmq.TCP_KEEPALIVE_IDLE: keepalive_timeout,
+                    zmq.TCP_KEEPALIVE_INTVL: keepalive_interval,
+                    zmq.TCP_KEEPALIVE_CNT: keepalive_retry_count,
                 },
             },
             serializer=msgpack.packb,
@@ -203,7 +214,7 @@ async def RPCContext(agent_id, addr, timeout=None, *, order_key: str = None):
         await peer.__aenter__()
         agent_peers[addr] = peer
     try:
-        with _timeout(timeout):
+        with _timeout(invoke_timeout):
             okey_token = peer.call.order_key.set('')
             try:
                 yield peer
@@ -259,6 +270,8 @@ class AgentRegistry:
         self.hook_plugin_ctx = hook_plugin_ctx
         self.kernel_creation_tracker = {}
         self._post_kernel_creation_tasks = weakref.WeakValueDictionary()
+        self.rpc_keepalive_timeout = \
+            int(shared_config.get("config/network/rpc/keepalive-timeout", "60"))
 
     async def init(self) -> None:
         self.heartbeat_lock = asyncio.Lock()
@@ -304,7 +317,11 @@ class AgentRegistry:
 
     async def gather_agent_hwinfo(self, instance_id: AgentId) -> Mapping[str, HardwareMetadata]:
         agent = await self.get_instance(instance_id, agents.c.addr)
-        async with RPCContext(agent['id'], agent['addr'], None) as rpc:
+        async with RPCContext(
+            agent['id'], agent['addr'],
+            invoke_timeout=None,
+            keepalive_timeout=self.rpc_keepalive_timeout,
+        ) as rpc:
             result = await rpc.call.gather_hwinfo()
             return {
                 k: check_typed_dict(v, HardwareMetadata)  # type: ignore  # (python/mypy#9827)
@@ -1171,8 +1188,9 @@ class AgentRegistry:
                     async with RPCContext(
                         kernel_agent_bindings[0].agent_alloc_ctx.agent_id,
                         kernel_agent_bindings[0].agent_alloc_ctx.agent_addr,
-                        None,
+                        invoke_timeout=None,
                         order_key=scheduled_session.session_id,
+                        keepalive_timeout=self.rpc_keepalive_timeout,
                     ) as rpc:
                         await rpc.call.create_local_network(network_name)
                 except Exception:
@@ -1338,8 +1356,9 @@ class AgentRegistry:
         async with RPCContext(
             agent_alloc_ctx.agent_id,
             agent_alloc_ctx.agent_addr,
-            None,
+            inovke_timeout=None,
             order_key=scheduled_session.session_id,
+            keepalive_timeout=self.rpc_keepalive_timeout,
         ) as rpc:
             kernel_creation_id = secrets.token_urlsafe(16)
             # Prepare kernel_started event handling
@@ -1606,8 +1625,9 @@ class AgentRegistry:
             async with RPCContext(
                 destroyed_kernels[0]['agent'],
                 destroyed_kernels[0]['agent_addr'],
-                None,
+                invoke_timeout=None,
                 order_key=session_id,
+                keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 for kernel in destroyed_kernels:
                     # internally it enqueues a "destroy" lifecycle event.
@@ -1801,8 +1821,9 @@ class AgentRegistry:
                     async with RPCContext(
                         destroyed_kernels[0]['agent'],
                         destroyed_kernels[0]['agent_addr'],
-                        None,
+                        invoke_timeout=None,
                         order_key=session['session_id'],
+                        keepalive_timeout=self.rpc_keepalive_timeout,
                     ) as rpc:
                         rpc_coros = []
                         for kernel in destroyed_kernels:
@@ -1883,8 +1904,9 @@ class AgentRegistry:
                 async with RPCContext(
                     session['agent'],       # the main-container's agent
                     session['agent_addr'],
-                    None,
+                    invoke_timeout=None,
                     order_key=session['session_id'],
+                    keepalive_timeout=self.rpc_keepalive_timeout,
                 ) as rpc:
                     await rpc.call.destroy_local_network(network_name)
             except Exception:
@@ -1952,8 +1974,9 @@ class AgentRegistry:
                     async with RPCContext(
                         kernel['agent'],       # the main-container's agent
                         kernel['agent_addr'],
-                        None,
+                        invoke_timeout=None,
                         order_key=None,
+                        keepalive_timeout=self.rpc_keepalive_timeout,
                     ) as rpc:
                         updated_config: Dict[str, Any] = {
                             # TODO: support resacling of sub-containers
@@ -2023,8 +2046,9 @@ class AgentRegistry:
             async with RPCContext(
                 kernel['agent'],
                 kernel['agent_addr'],
-                30,
+                invoke_timeout=30,
                 order_key=kernel['id'],
+                keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 return await rpc.call.execute(
                     str(kernel['id']),
@@ -2043,8 +2067,9 @@ class AgentRegistry:
             async with RPCContext(
                 kernel['agent'],
                 kernel['agent_addr'],
-                30,
+                invoke_timeout=30,
                 order_key=kernel['id'],
+                keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 return await rpc.call.interrupt_kernel(str(kernel['id']))
 
@@ -2060,8 +2085,9 @@ class AgentRegistry:
             async with RPCContext(
                 kernel['agent'],
                 kernel['agent_addr'],
-                10,
+                invoke_timeout=10,
                 order_key=kernel['id'],
+                keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 return await rpc.call.get_completions(str(kernel['id']), text, opts)
 
@@ -2077,8 +2103,9 @@ class AgentRegistry:
             async with RPCContext(
                 kernel['agent'],
                 kernel['agent_addr'],
-                None,
+                invoke_timeout=None,
                 order_key=kernel['id'],
+                keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 return await rpc.call.start_service(str(kernel['id']), service, opts)
 
@@ -2093,8 +2120,9 @@ class AgentRegistry:
             async with RPCContext(
                 kernel['agent'],
                 kernel['agent_addr'],
-                None,
+                invoke_timeout=None,
                 order_key=kernel['id'],
+                keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 return await rpc.call.shutdown_service(str(kernel['id']), service)
 
@@ -2110,8 +2138,9 @@ class AgentRegistry:
             async with RPCContext(
                 kernel['agent'],
                 kernel['agent_addr'],
-                None,
+                invoke_timeout=None,
                 order_key=kernel['id'],
+                keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 return await rpc.call.upload_file(str(kernel['id']), filename, payload)
 
@@ -2127,8 +2156,9 @@ class AgentRegistry:
             async with RPCContext(
                 kernel['agent'],
                 kernel['agent_addr'],
-                None,
+                invoke_timeout=None,
                 order_key=kernel['id'],
+                keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 return await rpc.call.download_file(str(kernel['id']), filepath)
 
@@ -2143,8 +2173,9 @@ class AgentRegistry:
             async with RPCContext(
                 kernel['agent'],
                 kernel['agent_addr'],
-                30,
+                invoke_timeout=30,
                 order_key=kernel['id'],
+                keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 return await rpc.call.list_files(str(kernel['id']), path)
 
@@ -2158,8 +2189,9 @@ class AgentRegistry:
             async with RPCContext(
                 kernel['agent'],
                 kernel['agent_addr'],
-                30,
+                invoke_timeout=30,
                 order_key=kernel['id'],
+                keepalive_timeout=self.rpc_keepalive_timeout,
             ) as rpc:
                 reply = await rpc.call.get_logs(str(kernel['id']))
                 return reply['logs']
@@ -2184,7 +2216,12 @@ class AgentRegistry:
         #     await execute_with_retry(conn, query)
 
     async def kill_all_sessions_in_agent(self, agent_id, agent_addr):
-        async with RPCContext(agent_id, agent_addr, None) as rpc:
+        async with RPCContext(
+            agent_id,
+            agent_addr,
+            invoke_timeout=None,
+            keepalive_timeout=self.rpc_keepalive_timeout,
+        ) as rpc:
             coro = rpc.call.clean_all_kernels('manager-freeze-force-kill')
             return await coro
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1356,7 +1356,7 @@ class AgentRegistry:
         async with RPCContext(
             agent_alloc_ctx.agent_id,
             agent_alloc_ctx.agent_addr,
-            inovke_timeout=None,
+            invoke_timeout=None,
             order_key=scheduled_session.session_id,
             keepalive_timeout=self.rpc_keepalive_timeout,
         ) as rpc:


### PR DESCRIPTION
The used etcd key is `config/network/rpc/keepalive-timeout` (default: 60 seconds).

Like Redis, the retry count is fixed to 3 times and the retry interval is calculated
from the given idle timeout with the minimum of 2 seconds.

