### PR TITLE
fix: unable to get response from usage per period API

### DIFF
--- a/changes/487.fix
+++ b/changes/487.fix
@@ -1,0 +1,1 @@
+Remove deferrable=True option to start DB transaction. Since the manager now opens a persistent DB transaction by #482, so deferrable transactions barely can be started.

--- a/changes/487.fix
+++ b/changes/487.fix
@@ -1,1 +1,1 @@
-Remove deferrable=True option to start DB transaction. Since the manager now opens a persistent DB transaction by #482, so deferrable transactions barely can be started.
+Remove `deferrable=True` option from the DB transaction to read session usage statistics. Since the manager now keeps repeatedly creating implicitly started DB transactions to acquire advisory locks (#482) and deferrable transactions barely can be started.

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -292,7 +292,7 @@ async def recalculate_usage(request: web.Request) -> web.Response:
 
 async def get_container_stats_for_period(request: web.Request, start_date, end_date, group_ids=None):
     root_ctx: RootContext = request.app['_root.context']
-    async with root_ctx.db.begin_readonly(deferrable=True) as conn:
+    async with root_ctx.db.begin_readonly() as conn:
         j = (
             kernels
             .join(groups, groups.c.id == kernels.c.group_id)


### PR DESCRIPTION
After [the PR #482 to replace aioredlock with pg_advisory_lock](https://github.com/lablup/backend.ai-manager/pull/482), a client cannot get the response from session usage per period API endpoints (`/usage/xxx`). It is due to the `deferrable=True` option in starting DB transactions. The manager now opens a persistent DB transaction by #482, we should not set the `deferrable` option, which instructs to start the current transaction only after other ongoing transactions are all finished.