### PR TITLE
fix: Adopt aioredis v2 lock (follow-up to #482, #483)

### DIFF
--- a/src/ai/backend/manager/api/context.py
+++ b/src/ai/backend/manager/api/context.py
@@ -34,6 +34,7 @@ class RootContext(BaseContext):
     redis_stat: RedisConnectionInfo
     redis_image: RedisConnectionInfo
     redis_stream: RedisConnectionInfo
+    redis_lock: RedisConnectionInfo
     shared_config: SharedConfig
     local_config: LocalConfig
     cors_options: CORSOptions

--- a/src/ai/backend/manager/api/logs.py
+++ b/src/ai/backend/manager/api/logs.py
@@ -255,7 +255,7 @@ async def init(app: web.Application) -> None:
         db=REDIS_LIVE_DB,
     )
     app_ctx.log_cleanup_timer = GlobalTimer(
-        root_ctx.db,
+        root_ctx.redis_lock,
         AdvisoryLock.LOCKID_LOG_CLEANUP_TIMER,
         root_ctx.event_producer,
         lambda: DoLogCleanupEvent(),

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -29,6 +29,7 @@ REDIS_RLIM_DB: Final = 1
 REDIS_LIVE_DB: Final = 2
 REDIS_IMAGE_DB: Final = 3
 REDIS_STREAM_DB: Final = 4
+REDIS_LOCK_DB: Final = 4
 
 
 # PostgreSQL session-level advisory lock indentifiers

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -29,7 +29,7 @@ REDIS_RLIM_DB: Final = 1
 REDIS_LIVE_DB: Final = 2
 REDIS_IMAGE_DB: Final = 3
 REDIS_STREAM_DB: Final = 4
-REDIS_LOCK_DB: Final = 4
+REDIS_LOCK_DB: Final = 5
 
 
 # PostgreSQL session-level advisory lock indentifiers

--- a/src/ai/backend/manager/distributed.py
+++ b/src/ai/backend/manager/distributed.py
@@ -56,6 +56,7 @@ class GlobalTimer:
                 async with lock:
                     print(f"lock[{self.timer_id}] acquired")
                     await self._event_producer.produce_event(self._event_factory())
+                    await lock.extend(self.interval)
                     await asyncio.sleep(self.interval)
                 print(f"lock[{self.timer_id}] released")
         except asyncio.CancelledError:

--- a/src/ai/backend/manager/distributed.py
+++ b/src/ai/backend/manager/distributed.py
@@ -7,8 +7,12 @@ from typing import (
     TYPE_CHECKING,
 )
 
+import aioredis.lock
+
+from ai.backend.common.redis import Lock
+
 if TYPE_CHECKING:
-    from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
+    from ai.backend.common.types import RedisConnectionInfo
     from ai.backend.common.events import AbstractEvent, EventProducer
 
 
@@ -23,27 +27,37 @@ class GlobalTimer:
 
     def __init__(
         self,
-        db: ExtendedAsyncSAEngine,
+        redis_lock: RedisConnectionInfo,
         timer_id: int,
         event_producer: EventProducer,
         event_factory: Callable[[], AbstractEvent],
         interval: float = 10.0,
         initial_delay: float = 0.0,
     ) -> None:
-        self.db = db
-        self.timer_id = timer_id
+        self._redis_lock = redis_lock
         self._event_producer = event_producer
         self._event_factory = event_factory
+        self.timer_id = timer_id
         self.interval = interval
         self.initial_delay = initial_delay
 
     async def generate_tick(self) -> None:
+        lock_key = f'lock:{self.timer_id}'
+        redis_client = await self._redis_lock.get_client()
+        lock: aioredis.lock.Lock = redis_client.lock(
+            lock_key,
+            blocking_timeout=0.1,
+            lock_class=Lock,
+        )
         try:
             await asyncio.sleep(self.initial_delay)
             while True:
-                async with self.db.advisory_lock(self.timer_id):
+                print(f"lock[{self.timer_id}] enter loop")
+                async with lock:
+                    print(f"lock[{self.timer_id}] acquired")
                     await self._event_producer.produce_event(self._event_factory())
                     await asyncio.sleep(self.interval)
+                print(f"lock[{self.timer_id}] released")
         except asyncio.CancelledError:
             pass
 


### PR DESCRIPTION
- fix: Rewrite GlobalTimer to use aioredis v2's lock impl.
- fix: Oops
- fix: explicitly extend the lock
