### PR TITLE
feat: add mutation query for agents table to update schedulable column

### DIFF
--- a/changes/500.feature
+++ b/changes/500.feature
@@ -1,1 +1,1 @@
-Provide mutable GQL query for the `schedulable` value of agent
+Add a new GQL mutation to modify the `schedulable` attribute of agents

--- a/changes/500.feature
+++ b/changes/500.feature
@@ -1,0 +1,1 @@
+Provide mutable GQL query for the `schedulable` value of agent

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -324,7 +324,7 @@ class Agent(graphene.ObjectType):
 
 
 class ModifyAgentInput(graphene.InputObjectType):
-    schedulable = graphene.Boolean(required=True, default=True)
+    schedulable = graphene.Boolean(required=False, default=True)
 
 
 class AgentList(graphene.ObjectType):

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import enum
 from typing import (
     Any,
+    Dict,
     Mapping,
     Sequence,
     TYPE_CHECKING,
@@ -27,11 +28,16 @@ from ai.backend.common.types import (
 
 from .kernel import AGENT_RESOURCE_OCCUPYING_KERNEL_STATUSES, kernels
 from .base import (
-    metadata,
     batch_result,
-    EnumType, Item, PaginatedList,
+    EnumType, Item,
+    metadata,
+    PaginatedList,
+    privileged_mutation,
     ResourceSlotColumn,
+    set_if_set,
+    simple_db_mutate,
 )
+from .user import UserRole
 from .minilang.queryfilter import QueryFilterParser
 from .minilang.ordering import QueryOrderParser
 if TYPE_CHECKING:
@@ -39,7 +45,7 @@ if TYPE_CHECKING:
 
 __all__: Sequence[str] = (
     'agents', 'AgentStatus',
-    'AgentList', 'Agent',
+    'AgentList', 'Agent', 'ModifyAgent',
     'recalc_agent_resource_occupancy',
 )
 
@@ -317,6 +323,10 @@ class Agent(graphene.ObjectType):
             )
 
 
+class ModifyAgentInput(graphene.InputObjectType):
+    schedulable = graphene.Boolean(required=True, default=True)
+
+
 class AgentList(graphene.ObjectType):
     class Meta:
         interfaces = (PaginatedList, )
@@ -347,3 +357,36 @@ async def recalc_agent_resource_occupancy(db_conn: SAConnection, agent_id: Agent
         .where(agents.c.id == agent_id)
     )
     await db_conn.execute(query)
+
+
+class ModifyAgent(graphene.Mutation):
+
+    allowed_roles = (UserRole.SUPERADMIN,)
+
+    class Arguments:
+        id = graphene.String(required=True)
+        props = ModifyAgentInput(required=True)
+
+    ok = graphene.Boolean()
+    msg = graphene.String()
+
+    @classmethod
+    @privileged_mutation(
+        UserRole.SUPERADMIN,
+        lambda id, **kwargs: (None, id),
+    )
+    async def mutate(
+        cls,
+        root,
+        info: graphene.ResolveInfo,
+        id: str,
+        props: ModifyAgentInput,
+    ) -> ModifyAgent:
+        graph_ctx: GraphQueryContext = info.context
+        data: Dict[str, Any] = {}
+        set_if_set(props, data, 'schedulable')
+
+        update_query = (
+            sa.update(agents).values(data).where(agents.c.id == id)
+        )
+        return await simple_db_mutate(cls, graph_ctx, update_query)

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -30,6 +30,7 @@ from .base import DataLoaderManager, privileged_query, scoped_query
 from .agent import (
     Agent,
     AgentList,
+    ModifyAgent,
 )
 from .domain import (
     Domain,
@@ -145,6 +146,9 @@ class Mutations(graphene.ObjectType):
     """
     All available GraphQL mutations.
     """
+
+    # super-admin only
+    modify_agent = ModifyAgent.Field()
 
     # super-admin only
     create_domain = CreateDomain.Field()


### PR DESCRIPTION
This PR provides the mutation query of agent setting.
For now, the user with superadmin role can update `schedulable` value only.

Related PR: [backend.ai-webui#1167](https://github.com/lablup/backend.ai-webui/pull/1167).