### PR TITLE
fix: Regression of stats API after applying asyncpg

### DIFF
--- a/changes/502.fix
+++ b/changes/502.fix
@@ -1,1 +1,1 @@
-Replace `rowcounts` to len function in getting usage aggregation query result
+Fix a regression of the usage stats aggregation API due to difference of aiopg and asyncpg behavior on `rowcount` of SELECT query results, by replacing `.rowcount` to `len()`

--- a/changes/502.fix
+++ b/changes/502.fix
@@ -1,0 +1,1 @@
+Replace `rowcounts` to len function in getting usage aggregation query result

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -523,7 +523,7 @@ async def get_time_binned_monthly_stats(request: web.Request, user_uuid=None):
         rows = result.fetchall()
 
     # Build time-series of time-binned stats.
-    rowcount = result.rowcount
+    rowcount = len(rows)
     now_ts = now.timestamp()
     start_date_ts = start_date.timestamp()
     ts = start_date_ts


### PR DESCRIPTION
This PR resolves the issue of sending empty responses by changing `rowcount` in query results to `len()` function in aggregating session usages,  since the query clause is `SELECT`.

Please refer to rowcount description at [sqlalchemy documentation](https://docs.sqlalchemy.org/en/14/core/connections.html?highlight=rowcount#sqlalchemy.engine.CursorResult.rowcount).