### PR TITLE
feat: Move max_containers_per_session policy check from predicates

### DIFF
--- a/changes/504.feature
+++ b/changes/504.feature
@@ -1,0 +1,1 @@
+Move 'max_containers_per_session' policy check from predicates to registry.enqueue_session

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -269,7 +269,7 @@ async def _query_userinfo(
     request: web.Request,
     params: Any,
     conn: SAConnection,
-) -> Tuple[uuid.UUID, uuid.UUID, str]:
+) -> Tuple[uuid.UUID, uuid.UUID, dict]:
     if params['domain'] is None:
         params['domain'] = request['user']['domain_name']
     scopes_param = {

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -758,7 +758,7 @@ class AgentRegistry:
         kernel_enqueue_configs: List[KernelEnqueueingConfig],
         scaling_group: Optional[str],
         session_type: SessionTypes,
-        resource_policy: str,
+        resource_policy: dict,
         *,
         domain_name: str,
         group_id: uuid.UUID,

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -100,6 +100,7 @@ from .api.exceptions import (
     VFolderNotFound,
     AgentError,
     GenericForbidden,
+    QuotaExceeded
 )
 from .config import SharedConfig
 from .exceptions import MultiAgentError
@@ -775,6 +776,10 @@ class AgentRegistry:
         mounts = kernel_enqueue_configs[0]['creation_config'].get('mounts') or []
         mount_map = kernel_enqueue_configs[0]['creation_config'].get('mount_map') or {}
         session_id = SessionId(uuid.uuid4())
+
+        # Check keypair resource limit
+        if cluster_size > resource_policy['max_containers_per_session']:
+            raise QuotaExceeded(f"You cannot create session with more than {resource_policy['max_containers_per_session']}")
 
         # Check scaling group availability if scaling_group parameter is given.
         # If scaling_group is not provided, it will be selected as the first one among

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -100,7 +100,7 @@ from .api.exceptions import (
     VFolderNotFound,
     AgentError,
     GenericForbidden,
-    QuotaExceeded
+    QuotaExceeded,
 )
 from .config import SharedConfig
 from .exceptions import MultiAgentError
@@ -778,8 +778,11 @@ class AgentRegistry:
         session_id = SessionId(uuid.uuid4())
 
         # Check keypair resource limit
-        if cluster_size > resource_policy['max_containers_per_session']:
-            raise QuotaExceeded(f"You cannot create session with more than {resource_policy['max_containers_per_session']}")
+        if cluster_size > int(resource_policy['max_containers_per_session']):
+            raise QuotaExceeded(
+                f"You cannot create session with more than "
+                f"{resource_policy['max_containers_per_session']} containers.",
+            )
 
         # Check scaling group availability if scaling_group parameter is given.
         # If scaling_group is not provided, it will be selected as the first one among

--- a/src/ai/backend/manager/scheduler/predicates.py
+++ b/src/ai/backend/manager/scheduler/predicates.py
@@ -119,13 +119,6 @@ async def check_keypair_resource_limit(
     )
     result = await db_conn.execute(query)
     resource_policy = result.first()
-    if len(sess_ctx.kernels) > resource_policy['max_containers_per_session']:
-        return PredicateResult(
-            False,
-            f"You cannot create session with more than "
-            f"{resource_policy['max_containers_per_session']} containers.",
-            permanent=True,
-        )
     total_keypair_allowed = ResourceSlot.from_policy(resource_policy,
                                                      sched_ctx.known_slot_types)
     key_occupied = await sched_ctx.registry.get_keypair_occupancy(


### PR DESCRIPTION
Resolve lablup/backend.ai/issues/308

* Move the check for "max-containers-per-session" of keypair resource policies from predicates to enqueueu_session of registry.py
* Regardless of the end of existing sessions , This check is determined by resource policy. 

### Result
* When the number of containers exceeds 'max_containers_per_session'
<img width="1312" alt="Screen Shot 2021-12-15 at 8 51 43 PM" src="https://user-images.githubusercontent.com/68562176/146181640-424b7fa6-784e-46b9-968d-12df0ec6d558.png">

