### PR TITLE
feat: Add support for session renaming

### DIFF
--- a/changes/505.feature
+++ b/changes/505.feature
@@ -1,0 +1,1 @@
+add support for session name renaming

--- a/changes/505.feature
+++ b/changes/505.feature
@@ -1,1 +1,1 @@
-add support for session name renaming
+Add support for session renaming

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1376,14 +1376,17 @@ async def stats_report_timer(root_ctx: RootContext):
     t.Dict({
         tx.AliasedKey(['name', 'clientSessionToken']) >> 'session_name':
             t.Regexp(r'^(?=.{4,64}$)\w[\w.-]*\w$', re.ASCII),
-    })
+    }),
 )
 async def rename_session(request: web.Request, params: Any) -> web.Response:
     root_ctx: RootContext = request.app['_root.context']
     session_name = request.match_info['session_name']
     new_name = params['session_name']
     requester_access_key, owner_access_key = await get_access_key_scopes(request)
-    log.info('RENAME_SESSION (ak:{0}/{1}, s:{2}, newname:{3})', request, owner_access_key, session_name, new_name)
+    log.info(
+        'RENAME_SESSION (ak:{0}/{1}, s:{2}, newname:{3})',
+        request, owner_access_key, session_name, new_name,
+    )
     async with root_ctx.db.begin() as conn:
         compute_session = await root_ctx.registry.get_session(
             session_name, owner_access_key,
@@ -1399,7 +1402,7 @@ async def rename_session(request: web.Request, params: Any) -> web.Response:
             .where(kernels.c.session_id == compute_session['session_id'])
         )
         await conn.execute(query)
-    
+
     return web.Response(status=204)
 
 

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1370,6 +1370,39 @@ async def stats_report_timer(root_ctx: RootContext):
             break
 
 
+@server_status_required(ALL_ALLOWED)
+@auth_required
+@check_api_params(
+    t.Dict({
+        tx.AliasedKey(['name', 'clientSessionToken']) >> 'session_name':
+            t.Regexp(r'^(?=.{4,64}$)\w[\w.-]*\w$', re.ASCII),
+    })
+)
+async def rename_session(request: web.Request, params: Any) -> web.Response:
+    root_ctx: RootContext = request.app['_root.context']
+    session_name = request.match_info['session_name']
+    new_name = params['session_name']
+    requester_access_key, owner_access_key = await get_access_key_scopes(request)
+    log.info('RENAME_SESSION (ak:{0}/{1}, s:{2}, newname:{3})', request, owner_access_key, session_name, new_name)
+    async with root_ctx.db.begin() as conn:
+        compute_session = await root_ctx.registry.get_session(
+            session_name, owner_access_key,
+            allow_stale=True,
+            db_connection=conn,
+        )
+        if compute_session['status'] != KernelStatus.RUNNING:
+            raise InvalidAPIParameters('Can\'t change name of not running session')
+
+        query = (
+            sa.update(kernels)
+            .values(session_name=new_name)
+            .where(kernels.c.session_id == compute_session['session_id'])
+        )
+        await conn.execute(query)
+    
+    return web.Response(status=204)
+
+
 @server_status_required(READ_ALLOWED)
 @auth_required
 @check_api_params(
@@ -2003,6 +2036,7 @@ def create_app(default_cors_options: CORSOptions) -> Tuple[web.Application, Iter
     cors.add(task_log_resource.add_route('HEAD', get_task_logs))
     cors.add(task_log_resource.add_route('GET',  get_task_logs))
     cors.add(app.router.add_route('GET',  '/{session_name}/logs', get_container_logs))
+    cors.add(app.router.add_route('POST', '/{session_name}/rename', rename_session))
     cors.add(app.router.add_route('POST', '/{session_name}/interrupt', interrupt))
     cors.add(app.router.add_route('POST', '/{session_name}/complete', complete))
     cors.add(app.router.add_route('POST', '/{session_name}/shutdown-service', shutdown_service))


### PR DESCRIPTION
This PR adds new rename_session API, as described on lablup/backend.ai#296.