### PR TITLE
fix: Avoid TooManySessions error when there is an exact match, not only prefix matches

### DIFF
--- a/changes/506.fix
+++ b/changes/506.fix
@@ -1,1 +1,1 @@
-Fix too many session matching problem when exectue app by session_name
+Fix "too many sessions matched" error when the given session name has an exact match with additional prefix matches

--- a/changes/506.fix
+++ b/changes/506.fix
@@ -1,0 +1,1 @@
+Fix too many session matching problem when exectue app by session_name

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -427,8 +427,6 @@ async def match_session_ids(
     ]:
         result = await db_connection.execute(match_query)
         rows = result.fetchall()
-        print("rows")
-        print("rows, len(lows)", rows, len(rows))
         if not rows:
             continue
         return [

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -301,6 +301,7 @@ class SessionInfo(TypedDict):
     status: KernelStatus
     created_at: datetime
 
+
 async def match_session_ids(
     session_name_or_id: Union[str, UUID],
     access_key: AccessKey,

--- a/src/ai/backend/manager/models/kernel.py
+++ b/src/ai/backend/manager/models/kernel.py
@@ -301,7 +301,6 @@ class SessionInfo(TypedDict):
     status: KernelStatus
     created_at: datetime
 
-
 async def match_session_ids(
     session_name_or_id: Union[str, UUID],
     access_key: AccessKey,
@@ -321,12 +320,17 @@ async def match_session_ids(
     )
     if extra_cond is not None:
         cond_id = cond_id & extra_cond
-    cond_name = (
+    cond_equal_name = (
+        (kernels.c.session_name == (f'{session_name_or_id}')) &
+        (kernels.c.access_key == access_key)
+    )
+    cond_prefix_name = (
         (kernels.c.session_name.like(f'{session_name_or_id}%')) &
         (kernels.c.access_key == access_key)
     )
     if extra_cond is not None:
-        cond_name = cond_name & extra_cond
+        cond_equal_name = cond_equal_name & extra_cond
+        cond_prefix_name = cond_prefix_name & extra_cond
     cond_session_id = (
         (sa.sql.expression.cast(kernels.c.session_id, sa.String).like(f'{session_name_or_id}%')) &
         (kernels.c.access_key == access_key)
@@ -358,7 +362,7 @@ async def match_session_ids(
     )
     if for_update:
         match_sid_by_id = match_sid_by_id.with_for_update()
-    match_sid_by_name = (
+    match_sid_by_equal_name = (
         sa.select(info_cols)
         .select_from(kernels)
         .where(
@@ -367,7 +371,24 @@ async def match_session_ids(
                     [kernels.c.session_id],
                 )
                 .select_from(kernels)
-                .where(cond_name)
+                .where(cond_equal_name)
+                .group_by(kernels.c.session_id)
+                .limit(max_matches).offset(0),
+            )) &
+            (kernels.c.cluster_role == DEFAULT_ROLE),
+        )
+        .order_by(sa.desc(kernels.c.created_at))
+    )
+    match_sid_by_prefix_name = (
+        sa.select(info_cols)
+        .select_from(kernels)
+        .where(
+            (kernels.c.session_id.in_(
+                sa.select(
+                    [kernels.c.session_id],
+                )
+                .select_from(kernels)
+                .where(cond_prefix_name)
                 .group_by(kernels.c.session_id)
                 .limit(max_matches).offset(0),
             )) &
@@ -376,7 +397,8 @@ async def match_session_ids(
         .order_by(sa.desc(kernels.c.created_at))
     )
     if for_update:
-        match_sid_by_name = match_sid_by_name.with_for_update()
+        match_sid_by_equal_name = match_sid_by_equal_name.with_for_update()
+        match_sid_by_prefix_name = match_sid_by_prefix_name.with_for_update()
     match_sid_by_session_id = (
         sa.select(info_cols)
         .select_from(kernels)
@@ -398,11 +420,14 @@ async def match_session_ids(
         match_sid_by_session_id = match_sid_by_session_id.with_for_update()
     for match_query in [
         match_sid_by_session_id,
-        match_sid_by_name,
+        match_sid_by_equal_name,
+        match_sid_by_prefix_name,
         match_sid_by_id,
     ]:
         result = await db_connection.execute(match_query)
         rows = result.fetchall()
+        print("rows")
+        print("rows, len(lows)", rows, len(rows))
         if not rows:
             continue
         return [

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -666,7 +666,6 @@ class AgentRegistry:
                 for_update=for_update,
                 extra_cond=extra_cond,
                 db_connection=conn,
-                max_matches=1,
             )
             if not session_infos:
                 raise SessionNotFound()

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -666,6 +666,7 @@ class AgentRegistry:
                 for_update=for_update,
                 extra_cond=extra_cond,
                 db_connection=conn,
+                max_matches=1,
             )
             if not session_infos:
                 raise SessionNotFound()


### PR DESCRIPTION
This pull request temporary solve the session_name matching problem (Too many sessions matched)

https://github.com/lablup/backend.ai/issues/297