### PR TITLE
Update mypy to 0.930

### DIFF
--- a/changes/508.fix
+++ b/changes/508.fix
@@ -1,0 +1,1 @@
+Update mypy to 0.930 and fix newly discovered type errors

--- a/setup.cfg
+++ b/setup.cfg
@@ -90,7 +90,7 @@ lint =
     flake8>=4.0.1
     flake8-commas>=2.1
 typecheck =
-    mypy>=0.910
+    mypy>=0.930
     types-click
     types-Jinja2
     types-pkg_resources

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -33,7 +33,7 @@ REDIS_STREAM_DB: Final = 4
 
 # PostgreSQL session-level advisory lock indentifiers
 class AdvisoryLock(enum.IntEnum):
-    LOCKID_TEST = 1
+    LOCKID_TEST = 42
     LOCKID_SCHEDULE = 91
     LOCKID_PREPARE = 92
     LOCKID_SCHEDULE_TIMER = 191

--- a/src/ai/backend/manager/distributed.py
+++ b/src/ai/backend/manager/distributed.py
@@ -7,6 +7,8 @@ from typing import (
     TYPE_CHECKING,
 )
 
+from ..defs import AdvisoryLock
+
 if TYPE_CHECKING:
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
     from ai.backend.common.events import AbstractEvent, EventProducer
@@ -41,7 +43,7 @@ class GlobalTimer:
         try:
             await asyncio.sleep(self.initial_delay)
             while True:
-                async with self.db.advisory_lock(self.timer_id):
+                async with self.db.advisory_lock(AdvisoryLock(self.timer_id)):
                     await self._event_producer.produce_event(self._event_factory())
                     await asyncio.sleep(self.interval)
         except asyncio.CancelledError:

--- a/src/ai/backend/manager/distributed.py
+++ b/src/ai/backend/manager/distributed.py
@@ -7,7 +7,7 @@ from typing import (
     TYPE_CHECKING,
 )
 
-from ..defs import AdvisoryLock
+from .defs import AdvisoryLock
 
 if TYPE_CHECKING:
     from ai.backend.manager.models.utils import ExtendedAsyncSAEngine

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -23,6 +23,7 @@ from typing import (
     Type,
     TypeVar,
     Union,
+    cast,
 )
 import sys
 import uuid
@@ -204,7 +205,7 @@ class GUID(TypeDecorator, Generic[UUID_SubType]):
     Uses PostgreSQL's UUID type, otherwise uses CHAR(16) storing as raw bytes.
     """
     impl = CHAR
-    uuid_subtype_func: ClassVar[Callable[[Any], UUID_SubType]] = lambda v: v
+    uuid_subtype_func: ClassVar[Callable[[Any], Any]] = lambda v: v
     cache_ok = True
 
     def load_dialect_impl(self, dialect):
@@ -236,14 +237,14 @@ class GUID(TypeDecorator, Generic[UUID_SubType]):
             return value
         else:
             cls = type(self)
-            return cls.uuid_subtype_func(uuid.UUID(value))
+            return cast(UUID_SubType, cls.uuid_subtype_func(uuid.UUID(value)))
 
 
-class SessionIDColumnType(GUID):
+class SessionIDColumnType(GUID[SessionId]):
     uuid_subtype_func = SessionId
 
 
-class KernelIDColumnType(GUID):
+class KernelIDColumnType(GUID[KernelId]):
     uuid_subtype_func = KernelId
 
 

--- a/tests/test_advisory_lock.py
+++ b/tests/test_advisory_lock.py
@@ -2,6 +2,7 @@ import asyncio
 
 import pytest
 
+from ai.backend.manager.defs import AdvisoryLock
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 
@@ -13,7 +14,7 @@ async def test_lock(database_engine: ExtendedAsyncSAEngine) -> None:
 
     async def critical_section(db: ExtendedAsyncSAEngine) -> None:
         nonlocal enter_count
-        async with db.advisory_lock(42):
+        async with db.advisory_lock(AdvisoryLock.LOCKID_TEST):
             enter_count += 1
             await asyncio.sleep(1.0)
 


### PR DESCRIPTION
This PR fixes new typecheck errors found by mypy 0.930 update.
