### PR TITLE
feat: Add mutation query for agents table to update scaling_group column

### DIFF
--- a/changes/511.feature
+++ b/changes/511.feature
@@ -1,1 +1,1 @@
-Add mutation query for agents table to update scaling_group column
+Allow modifying `scaling_group` field of an agent via the GraphQL mutation query, including an RPC call to the agent to update its own local configuration

--- a/changes/511.feature
+++ b/changes/511.feature
@@ -1,0 +1,1 @@
+Add mutation query for agents table to update scaling_group column

--- a/src/ai/backend/manager/models/agent.py
+++ b/src/ai/backend/manager/models/agent.py
@@ -325,6 +325,7 @@ class Agent(graphene.ObjectType):
 
 class ModifyAgentInput(graphene.InputObjectType):
     schedulable = graphene.Boolean(required=False, default=True)
+    scaling_group = graphene.String(required=False)
 
 
 class AgentList(graphene.ObjectType):
@@ -385,6 +386,8 @@ class ModifyAgent(graphene.Mutation):
         graph_ctx: GraphQueryContext = info.context
         data: Dict[str, Any] = {}
         set_if_set(props, data, 'schedulable')
+        set_if_set(props, data, 'scaling_group')
+        await graph_ctx.registry.update_scaling_group(id, data['scaling_group'])
 
         update_query = (
             sa.update(agents).values(data).where(agents.c.id == id)

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1529,6 +1529,16 @@ class AgentRegistry:
                 del key_occupied[k]
             return key_occupied
 
+    async def update_scaling_group(self, id, scaling_group) -> None:
+        agent = await self.get_instance(id, agents.c.addr)
+        async with RPCContext(
+            agent['id'], 
+            agent['addr'],
+            invoke_timeout=None,
+            keepalive_timeout=self.rpc_keepalive_timeout,
+        ) as rpc:
+            await rpc.call.update_scaling_group(scaling_group)
+
     async def recalc_resource_usage(self) -> None:
         concurrency_used_per_key: MutableMapping[str, int] = defaultdict(lambda: 0)
         occupied_slots_per_agent: MutableMapping[str, ResourceSlot] = \

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1532,7 +1532,7 @@ class AgentRegistry:
     async def update_scaling_group(self, id, scaling_group) -> None:
         agent = await self.get_instance(id, agents.c.addr)
         async with RPCContext(
-            agent['id'], 
+            agent['id'],
             agent['addr'],
             invoke_timeout=None,
             keepalive_timeout=self.rpc_keepalive_timeout,


### PR DESCRIPTION
Resolve: https://github.com/lablup/backend.ai/issues/317

Before DB update, It will call `update_scaling_group()` method of registry.py to update scaling group.

This PR can be merged after RPC method of agent is merged. 
https://github.com/lablup/backend.ai-agent/pull/327