### PR TITLE
feat: arbitrary path vfolder mounts

### DIFF
--- a/changes/515.feature
+++ b/changes/515.feature
@@ -1,0 +1,1 @@
+Non-entrypoint vfolder(none inside of /home/work directory) accept 

--- a/changes/515.feature
+++ b/changes/515.feature
@@ -1,1 +1,0 @@
-Non-entrypoint vfolder(none inside of /home/work directory) accept 

--- a/changes/516.feature
+++ b/changes/516.feature
@@ -1,0 +1,1 @@
+Vfolder mounting to root path(none inside of /home/work directory) accept 

--- a/changes/516.feature
+++ b/changes/516.feature
@@ -1,1 +1,1 @@
-Vfolder mounting to root path(none inside of /home/work directory) accept 
+Allow vfolder mounting to arbitrary path, excluding pre-existing folders of '/' like '/bin'.

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -409,7 +409,8 @@ async def _create(request: web.Request, params: Any) -> web.Response:
 
         alias_name: str
         for alias_name in alias_folders:
-            alias_name = alias_name.replace('/', '')
+            if alias_name.startswith("/home/work/"):
+                alias_name = alias_name.replace('/home/work/', '')
             if alias_name is None:
                 continue
             if alias_name == '':

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -409,10 +409,10 @@ async def _create(request: web.Request, params: Any) -> web.Response:
 
         alias_name: str
         for alias_name in alias_folders:
-            if alias_name.startswith("/home/work/"):
-                alias_name = alias_name.replace('/home/work/', '')
             if alias_name is None:
                 continue
+            if alias_name.startswith("/home/work/"):
+                alias_name = alias_name.replace('/home/work/', '')
             if alias_name == '':
                 raise InvalidAPIParameters('Alias name cannot be empty.')
             if not verify_vfolder_name(alias_name):

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -415,8 +415,7 @@ async def _create(request: web.Request, params: Any) -> web.Response:
             if alias_name == '':
                 raise InvalidAPIParameters('Alias name cannot be empty.')
             if not verify_vfolder_name(alias_name):
-                raise InvalidAPIParameters(f'Path {str(alias_name)} is reserved for \
-                                             internal operations.')
+                raise InvalidAPIParameters(str(alias_name) + ' is reserved for internal path.')
             if alias_name in original_folders:
                 raise InvalidAPIParameters('Alias name cannot be set to an existing folder name: '
                                             + str(alias_name))

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -409,6 +409,7 @@ async def _create(request: web.Request, params: Any) -> web.Response:
 
         alias_name: str
         for alias_name in alias_folders:
+            alias_name = alias_name.replace('/', '')
             if alias_name is None:
                 continue
             if alias_name == '':

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -407,18 +407,14 @@ async def _create(request: web.Request, params: Any) -> web.Response:
         if len(alias_folders) != len(set(alias_folders)):
             raise InvalidAPIParameters('Duplicate alias folder name exists.')
 
-        p: str
-        for p in alias_folders:
-            if p is None:
+        alias_name: str
+        for alias_name in alias_folders:
+            if alias_name is None:
                 continue
-            if not p.startswith('/home/work/'):
-                raise InvalidAPIParameters(f'Path {p} should start with /home/work/')
-
-            alias_name = p.replace('/home/work/', '')
             if alias_name == '':
                 raise InvalidAPIParameters('Alias name cannot be empty.')
             if not verify_vfolder_name(alias_name):
-                raise InvalidAPIParameters(f'Path {str(p)} is reserved for internal operations.')
+                raise InvalidAPIParameters(f'Path {str(alias_name)} is reserved for internal operations.')
             if alias_name in original_folders:
                 raise InvalidAPIParameters('Alias name cannot be set to an existing folder name: '
                                             + str(alias_name))

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -414,7 +414,8 @@ async def _create(request: web.Request, params: Any) -> web.Response:
             if alias_name == '':
                 raise InvalidAPIParameters('Alias name cannot be empty.')
             if not verify_vfolder_name(alias_name):
-                raise InvalidAPIParameters(f'Path {str(alias_name)} is reserved for internal operations.')
+                raise InvalidAPIParameters(f'Path {str(alias_name)} is reserved for \
+                                             internal operations.')
             if alias_name in original_folders:
                 raise InvalidAPIParameters('Alias name cannot be set to an existing folder name: '
                                             + str(alias_name))

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -21,8 +21,8 @@ DEFAULT_ROLE: Final = "main"
 _RESERVED_VFOLDER_PATTERNS = [r'^\.[a-z0-9]+rc$', r'^\.[a-z0-9]+_profile$']
 RESERVED_DOTFILES = ['.terminfo', '.jupyter', '.ssh', '.ssh/authorized_keys', '.local', '.config']
 RESERVED_VFOLDERS = ['.terminfo', '.jupyter', '.tmux.conf', '.ssh', '/bin', '/boot', '/dev', '/etc',
-                     '/lib', '/lib64', '/media', '/mnt', '/opt', '/proc', '/root', '/run', '/sbin', '/srv',
-                     '/sys', '/tmp', '/usr', '/var', '/home']
+                     '/lib', '/lib64', '/media', '/mnt', '/opt', '/proc', '/root', '/run', '/sbin',
+                     '/srv', '/sys', '/tmp', '/usr', '/var', '/home']
 RESERVED_VFOLDER_PATTERNS = [re.compile(x) for x in _RESERVED_VFOLDER_PATTERNS]
 
 # Redis database IDs depending on purposes

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -20,9 +20,9 @@ DEFAULT_ROLE: Final = "main"
 
 _RESERVED_VFOLDER_PATTERNS = [r'^\.[a-z0-9]+rc$', r'^\.[a-z0-9]+_profile$']
 RESERVED_DOTFILES = ['.terminfo', '.jupyter', '.ssh', '.ssh/authorized_keys', '.local', '.config']
-RESERVED_VFOLDERS = ['.terminfo', '.jupyter', '.tmux.conf', '.ssh', 'bin', 'boot', 'dev', 'etc', \
-                    'lib', 'lib64', 'media', 'mnt', 'opt', 'proc', 'root', 'run', 'sbin', 'srv', \
-                    'sys', 'tmp', 'usr', 'var', 'home']
+RESERVED_VFOLDERS = ['.terminfo', '.jupyter', '.tmux.conf', '.ssh', 'bin', 'boot', 'dev', 'etc',
+                     'lib', 'lib64', 'media', 'mnt', 'opt', 'proc', 'root', 'run', 'sbin', 'srv',
+                     'sys', 'tmp', 'usr', 'var', 'home']
 RESERVED_VFOLDER_PATTERNS = [re.compile(x) for x in _RESERVED_VFOLDER_PATTERNS]
 
 # Redis database IDs depending on purposes

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -22,7 +22,7 @@ _RESERVED_VFOLDER_PATTERNS = [r'^\.[a-z0-9]+rc$', r'^\.[a-z0-9]+_profile$']
 RESERVED_DOTFILES = ['.terminfo', '.jupyter', '.ssh', '.ssh/authorized_keys', '.local', '.config']
 RESERVED_VFOLDERS = ['.terminfo', '.jupyter', '.tmux.conf', '.ssh', 'bin', 'boot', 'dev', 'etc',
                      'lib', 'lib64', 'media', 'mnt', 'opt', 'proc', 'root', 'run', 'sbin', 'srv',
-                     'sys', 'tmp', 'usr', 'var', 'home']
+                     'sys', 'tmp', 'usr', 'var', 'home', 'home/work']
 RESERVED_VFOLDER_PATTERNS = [re.compile(x) for x in _RESERVED_VFOLDER_PATTERNS]
 
 # Redis database IDs depending on purposes

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -19,12 +19,10 @@ INTRINSIC_SLOTS: Final = {
 DEFAULT_ROLE: Final = "main"
 
 _RESERVED_VFOLDER_PATTERNS = [r'^\.[a-z0-9]+rc$', r'^\.[a-z0-9]+_profile$']
-RESERVED_DOTFILES = ['home/work/.terminfo', 'home/work/.jupyter', 'home/work/.ssh', 
-                     'home/work/.ssh/authorized_keys', 'home/work/.local', 'home/work/.config']
-RESERVED_VFOLDERS = ['home/work/.terminfo', 'home/work/.jupyter', 'home/work/.tmux.conf', 
-                     'home/work/.ssh', 'bin', 'boot', 'dev', 'etc',
-                     'lib', 'lib64', 'media', 'mnt', 'opt', 'proc', 'root', 'run', 'sbin', 'srv',
-                     'sys', 'tmp', 'usr', 'var', 'home', 'home/work']
+RESERVED_DOTFILES = ['.terminfo', '.jupyter', '.ssh', '.ssh/authorized_keys', '.local', '.config']
+RESERVED_VFOLDERS = ['.terminfo', '.jupyter', '.tmux.conf', '.ssh', '/bin', '/boot', '/dev', '/etc',
+                     '/lib', '/lib64', '/media', '/mnt', '/opt', '/proc', '/root', '/run', '/sbin', '/srv',
+                     '/sys', '/tmp', '/usr', '/var', '/home']
 RESERVED_VFOLDER_PATTERNS = [re.compile(x) for x in _RESERVED_VFOLDER_PATTERNS]
 
 # Redis database IDs depending on purposes

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -20,7 +20,9 @@ DEFAULT_ROLE: Final = "main"
 
 _RESERVED_VFOLDER_PATTERNS = [r'^\.[a-z0-9]+rc$', r'^\.[a-z0-9]+_profile$']
 RESERVED_DOTFILES = ['.terminfo', '.jupyter', '.ssh', '.ssh/authorized_keys', '.local', '.config']
-RESERVED_VFOLDERS = ['.terminfo', '.jupyter', '.tmux.conf', '.ssh']
+RESERVED_VFOLDERS = ['.terminfo', '.jupyter', '.tmux.conf', '.ssh', 'bin', 'boot', 'dev', 'etc', \
+                    'lib', 'lib64', 'media', 'mnt', 'opt', 'proc', 'root', 'run', 'sbin', 'srv', \
+                    'sys', 'tmp', 'usr', 'var', 'home']
 RESERVED_VFOLDER_PATTERNS = [re.compile(x) for x in _RESERVED_VFOLDER_PATTERNS]
 
 # Redis database IDs depending on purposes

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -19,8 +19,10 @@ INTRINSIC_SLOTS: Final = {
 DEFAULT_ROLE: Final = "main"
 
 _RESERVED_VFOLDER_PATTERNS = [r'^\.[a-z0-9]+rc$', r'^\.[a-z0-9]+_profile$']
-RESERVED_DOTFILES = ['.terminfo', '.jupyter', '.ssh', '.ssh/authorized_keys', '.local', '.config']
-RESERVED_VFOLDERS = ['.terminfo', '.jupyter', '.tmux.conf', '.ssh', 'bin', 'boot', 'dev', 'etc',
+RESERVED_DOTFILES = ['home/work/.terminfo', 'home/work/.jupyter', 'home/work/.ssh', 
+                     'home/work/.ssh/authorized_keys', 'home/work/.local', 'home/work/.config']
+RESERVED_VFOLDERS = ['home/work/.terminfo', 'home/work/.jupyter', 'home/work/.tmux.conf', 
+                     'home/work/.ssh', 'bin', 'boot', 'dev', 'etc',
                      'lib', 'lib64', 'media', 'mnt', 'opt', 'proc', 'root', 'run', 'sbin', 'srv',
                      'sys', 'tmp', 'usr', 'var', 'home', 'home/work']
 RESERVED_VFOLDER_PATTERNS = [re.compile(x) for x in _RESERVED_VFOLDER_PATTERNS]

--- a/src/ai/backend/manager/models/session_template.py
+++ b/src/ai/backend/manager/models/session_template.py
@@ -94,10 +94,10 @@ def check_task_template(raw_data: Mapping[str, Any]) -> Mapping[str, Any]:
     data = task_template_v1.check(raw_data)
     if mounts := data['spec'].get('mounts'):
         for p in mounts.values():
-            if p.startswith("/home/work/"):
-                p = p.replace("/home/work/", "")
             if p is None:
                 continue
+            if p.startswith("/home/work/"):
+                p = p.replace("/home/work/", "")
             if not verify_vfolder_name(p):
                 raise InvalidArgument(f'Path {p} is reserved for internal operations.')
     return data

--- a/src/ai/backend/manager/models/session_template.py
+++ b/src/ai/backend/manager/models/session_template.py
@@ -98,7 +98,7 @@ def check_task_template(raw_data: Mapping[str, Any]) -> Mapping[str, Any]:
                 continue
             if not p.startswith('/'):
                 raise InvalidArgument(f'Path {p} should be absolute path')
-            if not verify_vfolder_name(p.replace('/home/work/', '')):
+            if not verify_vfolder_name(p.replace('/', '')):
                 raise InvalidArgument(f'Path {p} is reserved for internal operations.')
     return data
 

--- a/src/ai/backend/manager/models/session_template.py
+++ b/src/ai/backend/manager/models/session_template.py
@@ -94,11 +94,11 @@ def check_task_template(raw_data: Mapping[str, Any]) -> Mapping[str, Any]:
     data = task_template_v1.check(raw_data)
     if mounts := data['spec'].get('mounts'):
         for p in mounts.values():
+            if p.startswith("/home/work/"):
+                p = p.replace("/home/work/", "")
             if p is None:
                 continue
-            if not p.startswith('/'):
-                raise InvalidArgument(f'Path {p} should be absolute path')
-            if not verify_vfolder_name(p.replace('/', '')):
+            if not verify_vfolder_name(p):
                 raise InvalidArgument(f'Path {p} is reserved for internal operations.')
     return data
 

--- a/src/ai/backend/manager/models/session_template.py
+++ b/src/ai/backend/manager/models/session_template.py
@@ -96,8 +96,8 @@ def check_task_template(raw_data: Mapping[str, Any]) -> Mapping[str, Any]:
         for p in mounts.values():
             if p is None:
                 continue
-            if not p.startswith('/home/work/'):
-                raise InvalidArgument(f'Path {p} should start with /home/work/')
+            if not p.startswith('/'):
+                raise InvalidArgument(f'Path {p} should be absolute path')
             if not verify_vfolder_name(p.replace('/home/work/', '')):
                 raise InvalidArgument(f'Path {p} is reserved for internal operations.')
     return data

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -54,6 +54,13 @@ def test_vfolder_name_validator():
     assert not verify_vfolder_name('.terminfo')
     assert verify_vfolder_name('bashrc')
     assert verify_vfolder_name('.config')
+    assert not verify_vfolder_name('bin')
+    assert not verify_vfolder_name('boot')
+    assert not verify_vfolder_name('run')
+    assert verify_vfolder_name('home/work/bin')
+    assert verify_vfolder_name('home/work/boot')
+    assert verify_vfolder_name('home/work/run')
+    assert not verify_vfolder_name('home/work')
 
 
 def test_dotfile_name_validator():

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -50,17 +50,20 @@ async def test_call_non_bursty():
 
 
 def test_vfolder_name_validator():
-    assert not verify_vfolder_name('home/work/.bashrc')
-    assert not verify_vfolder_name('home/work/.terminfo')
-    assert verify_vfolder_name('home/work/bashrc')
-    assert verify_vfolder_name('home/work/.config')
-    assert not verify_vfolder_name('bin')
-    assert not verify_vfolder_name('boot')
-    assert not verify_vfolder_name('run')
-    assert verify_vfolder_name('home/work/bin')
-    assert verify_vfolder_name('home/work/boot')
-    assert verify_vfolder_name('home/work/run')
-    assert not verify_vfolder_name('home/work')
+    assert not verify_vfolder_name('.bashrc')
+    assert not verify_vfolder_name('.terminfo')
+    assert verify_vfolder_name('bashrc')
+    assert verify_vfolder_name('.config')
+    assert verify_vfolder_name('bin')
+    assert verify_vfolder_name('boot')
+    assert verify_vfolder_name('root')
+    assert not verify_vfolder_name('/bin')
+    assert not verify_vfolder_name('/boot')
+    assert not verify_vfolder_name('/root')
+    assert verify_vfolder_name('/home/work/bin')
+    assert verify_vfolder_name('/home/work/boot')
+    assert verify_vfolder_name('/home/work/root')
+    assert verify_vfolder_name('home/work')
 
 
 def test_dotfile_name_validator():

--- a/tests/api/test_utils.py
+++ b/tests/api/test_utils.py
@@ -50,10 +50,10 @@ async def test_call_non_bursty():
 
 
 def test_vfolder_name_validator():
-    assert not verify_vfolder_name('.bashrc')
-    assert not verify_vfolder_name('.terminfo')
-    assert verify_vfolder_name('bashrc')
-    assert verify_vfolder_name('.config')
+    assert not verify_vfolder_name('home/work/.bashrc')
+    assert not verify_vfolder_name('home/work/.terminfo')
+    assert verify_vfolder_name('home/work/bashrc')
+    assert verify_vfolder_name('home/work/.config')
     assert not verify_vfolder_name('bin')
     assert not verify_vfolder_name('boot')
     assert not verify_vfolder_name('run')


### PR DESCRIPTION
Resolve: lablup/backend.ai#329

This is only about vfolder mount. Original functions of /home/work directory is not changed(logs, entrypoint, any other dotfiles).

Related PR:
lablup/backend.ai-agent#334 
lablup/backend.ai-webui#1194
lablup/backend.ai-client-py#204

**Test**
![test1](https://user-images.githubusercontent.com/31719811/150245393-f434c104-92f8-42de-89cf-a3a6b15821e0.PNG)
![test2](https://user-images.githubusercontent.com/31719811/150245402-25198d13-99bf-4c09-b14a-ec0c35018085.PNG)
![test3](https://user-images.githubusercontent.com/31719811/150245408-c690d3a9-c1e0-406f-a42b-14ef9cf7d9b7.PNG)
![test4](https://user-images.githubusercontent.com/31719811/150245417-692b7f4f-134d-41d9-a1c4-f962ef781eb0.PNG)

**Blacklist test**
![vfolder_test](https://user-images.githubusercontent.com/31719811/150859420-890a5bdb-ab01-45ad-abdb-ad99ec1e7dac.PNG)