### PR TITLE
fix: get_wsproxy_version raising GenericNotFound

### DIFF
--- a/changes/517.fix
+++ b/changes/517.fix
@@ -1,0 +1,1 @@
+Fix get_wsproxy_version API raising GenericNotFound when user's current domain isn't associated with target scaling group

--- a/src/ai/backend/manager/api/scaling_group.py
+++ b/src/ai/backend/manager/api/scaling_group.py
@@ -49,8 +49,10 @@ async def query_wsproxy_version(
     scaling_group_name: str,
 ) -> str:
     async with params.db_ctx.begin_readonly() as conn:
-        query = (sa.select([scaling_groups])
-                   .where((scaling_groups.c.name == scaling_group_name)))
+        query = (
+            sa.select([scaling_groups])
+              .where(scaling_groups.c.name == scaling_group_name)
+        )
         result = await conn.execute(query)
         matched_sgroup = result.first()
 

--- a/src/ai/backend/manager/api/scaling_group.py
+++ b/src/ai/backend/manager/api/scaling_group.py
@@ -51,7 +51,7 @@ async def query_wsproxy_version(
     async with params.db_ctx.begin_readonly() as conn:
         query = (
             sa.select([scaling_groups])
-              .where(scaling_groups.c.name == scaling_group_name)
+            .where(scaling_groups.c.name == scaling_group_name)
         )
         result = await conn.execute(query)
         matched_sgroup = result.first()

--- a/src/ai/backend/manager/api/scaling_group.py
+++ b/src/ai/backend/manager/api/scaling_group.py
@@ -50,10 +50,10 @@ async def query_wsproxy_version(
 ) -> str:
     async with params.db_ctx.begin_readonly() as conn:
         query = (sa.select([scaling_groups])
-                   .where((scaling_groups.c.name == scaling_group_name), ))
+                   .where((scaling_groups.c.name == scaling_group_name)))
         result = await conn.execute(query)
         matched_sgroup = result.first()
-    
+
     if matched_sgroup is None:
         raise GenericNotFound
 


### PR DESCRIPTION
This PR fixes error where get_wsproxy_version API raising GenericNotFound error when user's current domain isn't associated with target scaling group.