### PR TITLE
fix: declare down_task in TCPProxy to prevent AttributeError

### DIFF
--- a/changes/519.fix
+++ b/changes/519.fix
@@ -1,0 +1,1 @@
+Prevent `AttributeError` in proxying app requests by declaring `down_task` in `TCPProxy` class explicitly.

--- a/src/ai/backend/manager/api/wsproxy.py
+++ b/src/ai/backend/manager/api/wsproxy.py
@@ -71,6 +71,7 @@ class TCPProxy(ServiceProxy):
 
     def __init__(self, *args, **kwargs) -> None:
         super().__init__(*args, **kwargs)
+        self.down_task: Optional[asyncio.Task] = None
 
     async def proxy(self) -> web.WebSocketResponse:
         try:


### PR DESCRIPTION
In some rare cases, `TCPProxy` raises an `AttributeError` in proxying app requests like the image below.
<img width="1858" alt="image" src="https://user-images.githubusercontent.com/7539358/149651829-97d0d36d-7d96-4a30-b7fd-6a210ed18978.png">

This PR just explicitly declare the `down_task` attribute in the `TCPProxy` class to prevent the above issue.