### PR TITLE
fix: Reduce possibility of stuck in PREPARING under high-load conditions

### DIFF
--- a/changes/522.fix.md
+++ b/changes/522.fix.md
@@ -1,0 +1,1 @@
+Reduce possibility of new sessions to get stuck in the PREPARING status by improving synchronization of session/kernel creation trackers

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1192,9 +1192,11 @@ async def handle_kernel_creation_lifecycle(
     root_ctx: RootContext = app['_root.context']
     # ck_id = (event.creation_id, event.kernel_id)
     ck_id = event.kernel_id
-    if ck_id not in root_ctx.registry.kernel_creation_tracker:
-        return
-    log.debug('handle_kernel_creation_lifecycle: ev:{} k:{}', event.name, event.kernel_id)
+    if ck_id in root_ctx.registry.kernel_creation_tracker:
+        log.debug(
+            "handle_kernel_creation_lifecycle: ev:{} k:{}",
+            event.name, event.kernel_id,
+        )
     if isinstance(event, KernelPreparingEvent):
         # State transition is done by the DoPrepareEvent handler inside the scheduler-distpacher object.
         pass
@@ -1220,7 +1222,7 @@ async def handle_kernel_termination_lifecycle(
     if isinstance(event, KernelTerminatingEvent):
         # The destroy_kernel() API handler will set the "TERMINATING" status.
         pass
-    if isinstance(event, KernelTerminatedEvent):
+    elif isinstance(event, KernelTerminatedEvent):
         await root_ctx.registry.mark_kernel_terminated(event.kernel_id, event.reason, event.exit_code)
         await root_ctx.registry.check_session_terminated(event.kernel_id, event.reason)
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -35,7 +35,6 @@ import aiodocker
 import aiohttp
 import aioredis
 import aiotools
-from aioredis import Redis
 from async_timeout import timeout as _timeout
 from callosum.rpc import Peer, RPCUserError
 from callosum.lower.zeromq import ZeroMQAddress, ZeroMQRPCTransport


### PR DESCRIPTION
- fix: Apply nested transaction to `check_scaling_group` predicate
- fix: minor code clean up
- refactor: Remove legacy stat-sync codes and apply batching
- fix: Improve synchronization of kernel creation postprocessing
