### PR TITLE
upstream: Migrate to aiodataloader-ng

### DIFF
--- a/changes/525.fix.md
+++ b/changes/525.fix.md
@@ -1,0 +1,1 @@
+Migrate aiodataloader to aiodataloader-ng, which is managed by us

--- a/setup.cfg
+++ b/setup.cfg
@@ -34,7 +34,7 @@ setup_requires =
     setuptools>=51.1.1
     wheel>=0.36.2
 install_requires =
-    aiodataloader
+    aiodataloader-ng~=0.2.1
     aiodocker~=0.21.0
     aiofiles~=0.7.0
     aiohttp~=3.8.0


### PR DESCRIPTION
refs lablup/backend.ai#300

This will allow running Backend.AI Manager on Python 3.10.