### PR TITLE
fix: admins cannot terminate inactivated user's compute sessions

### DIFF
--- a/changes/530.fix
+++ b/changes/530.fix
@@ -1,0 +1,1 @@
+Fix admin can't session which deactivated user owns

--- a/changes/530.fix
+++ b/changes/530.fix
@@ -1,1 +1,1 @@
-Fix admin can't session which deactivated user owns
+Allow admins to take actions on behalf of "inactivated" keypairs, such as terminating an RUNNING compute session created by the inactive keypair.

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -65,10 +65,7 @@ async def get_access_key_scopes(request: web.Request, params: Any = None) -> Tup
                 .select_from(
                     sa.join(keypairs, users,
                             keypairs.c.user == users.c.uuid))
-                .where(
-                    (keypairs.c.access_key == owner_access_key)
-                    & (keypairs.c.is_active == true()),
-                )
+                .where(keypairs.c.access_key == owner_access_key)
             )
             result = await conn.execute(query)
             row = result.first()

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -75,7 +75,7 @@ async def get_access_key_scopes(request: web.Request, params: Any = None) -> Tup
             if row is None:
                 requester_query = (
                     sa.select([users.c.domain_name, users.c.role]).select_from(
-                        sa.join(keypairs, users, keypairs.c.user == users.c.uuid,)
+                        sa.join(keypairs, users, keypairs.c.user == users.c.uuid),
                     ).where(
                         (keypairs.c.access_key == requester_access_key) &
                         (keypairs.c.is_active == true()),

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -73,23 +73,9 @@ async def get_access_key_scopes(request: web.Request, params: Any = None) -> Tup
             result = await conn.execute(query)
             row = result.first()
             if row is None:
-                requester_query = (
-                    sa.select([users.c.domain_name, users.c.role]).select_from(
-                        sa.join(keypairs, users, keypairs.c.user == users.c.uuid),
-                    ).where(
-                        (keypairs.c.access_key == requester_access_key) &
-                        (keypairs.c.is_active == true()),
-                    )
-                )
-                requester_result = await conn.execute(requester_query)
-                requester_row = requester_result.first()
-                if requester_row is None:
-                    raise InvalidAPIParameters("Unknown or inactive owner access key")
-                owner_domain = requester_row["domain_name"]
-                owner_role = requester_row["role"]
-            else:
-                owner_domain = row["domain_name"]
-                owner_role = row["role"]
+                raise InvalidAPIParameters('Unknown or inactive owner access key')
+            owner_domain = row['domain_name']
+            owner_role = row['role']
         if request['is_superadmin']:
             pass
         elif request['is_admin']:

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -62,10 +62,10 @@ async def get_access_key_scopes(request: web.Request, params: Any = None) -> Tup
         async with root_ctx.db.begin() as conn:
             query = (
                 sa.select([users.c.domain_name, users.c.role])
-                    .select_from(
+                .select_from(
                     sa.join(keypairs, users,
                             keypairs.c.user == users.c.uuid))
-                    .where(
+                .where(
                     (keypairs.c.access_key == owner_access_key)
                     & (keypairs.c.is_active == true()),
                 )
@@ -75,10 +75,10 @@ async def get_access_key_scopes(request: web.Request, params: Any = None) -> Tup
             if row is None:
                 requester_query = (
                     sa.select([users.c.domain_name, users.c.role]).select_from(
-                        sa.join(keypairs, users, keypairs.c.user == users.c.uuid)
+                        sa.join(keypairs, users, keypairs.c.user == users.c.uuid,)
                     ).where(
                         (keypairs.c.access_key == requester_access_key) &
-                        (keypairs.c.is_active == true())
+                        (keypairs.c.is_active == true()),
                     )
                 )
                 requester_result = await conn.execute(requester_query)

--- a/src/ai/backend/manager/api/utils.py
+++ b/src/ai/backend/manager/api/utils.py
@@ -26,7 +26,6 @@ from typing import (
 from aiohttp import web
 import trafaret as t
 import sqlalchemy as sa
-from sqlalchemy.sql.expression import true
 import yaml
 
 from ai.backend.common.logging import BraceStyleAdapter


### PR DESCRIPTION
 Resolve: https://github.com/lablup/backend.ai/issues/358

Add query code when activated user is not found while remove user session.