### PR TITLE
fix: occupied slot not released when session creation fails

### DIFF
--- a/changes/531.fix
+++ b/changes/531.fix
@@ -1,0 +1,1 @@
+Force resource usage recalculation when session creation is failed to prevent failed session's resource slot not returning.

--- a/src/ai/backend/manager/scheduler/dispatcher.py
+++ b/src/ai/backend/manager/scheduler/dispatcher.py
@@ -810,6 +810,7 @@ class SchedulerDispatcher(aobject):
                 await self.registry.destroy_session_lowlevel(
                     session.session_id, destroyed_kernels,
                 )
+                await self.registry.recalc_resource_usage()
             except Exception as destroy_err:
                 log.error(log_fmt + 'cleanup-start-failure: error', *log_args, exc_info=destroy_err)
             finally:


### PR DESCRIPTION
This PR closes lablup/backend.ai#315, by forcing resource usage recalculation when session creation is failed.