### PR TITLE
Fix/prevent blocking of the whole manager while cloning a vfolder

### DIFF
--- a/src/ai/backend/manager/api/vfolder.py
+++ b/src/ai/backend/manager/api/vfolder.py
@@ -1828,6 +1828,7 @@ async def clone(request: web.Request, params: Any, row: VFolderRow) -> web.Respo
             'user': user_uuid,
             'group': group_uuid,
             'cloneable': params['cloneable'],
+            'bgtask_id': task_id.hex,
         }
         query = (sa.insert(vfolders, insert_values))
         try:


### PR DESCRIPTION
resolved : https://github.com/lablup/backend.ai/issues/354

**prevent blocking of the whole manager while cloning a vfolder**
- **Run the clone operation as a background task and just return the bgtask ID in the vfolder clone API, so that clients could keep track of the progress and result.**
![clone pr](https://user-images.githubusercontent.com/18081105/154634891-a2a2bbf1-554b-4bea-8446-c9156b5cc812.png)

- **Split the destination vfolder creation and actual clone operations, and insert the database transaction to create the destination vfolder record between them.**
![split](https://user-images.githubusercontent.com/18081105/154635456-ed1052ad-6bb3-410a-b94d-044c79f4b85b.png)

