### PR TITLE
fix: Don't allow empty values in allowed session types and scan all allowed scaling groups

### DIFF
--- a/changes/542.fix
+++ b/changes/542.fix
@@ -1,1 +1,1 @@
-Fix 'allowed_session_types' as not empty using trafaret and Prevent stopping without checking all sgroups during the 'allowed_session_types' check process
+Disallow empty values in `allowed_session_types` of scheduler options and fix the predicate check to scan all scaling groups

--- a/changes/542.fix
+++ b/changes/542.fix
@@ -1,0 +1,1 @@
+Fix 'allowed_session_types' as not empty using trafaret and Prevent stopping without checking all sgroups during the 'allowed_session_types' check process

--- a/src/ai/backend/manager/models/scaling_group.py
+++ b/src/ai/backend/manager/models/scaling_group.py
@@ -71,7 +71,7 @@ scaling_groups = sa.Table(
     sa.Column('scheduler_opts', StructuredJSONBColumn(
         t.Dict({
             t.Key('allowed_session_types', default=['interactive', 'batch']):
-                t.List(tx.Enum(SessionTypes), min_length = 1),
+                t.List(tx.Enum(SessionTypes), min_length=1),
         }).allow_extra('*'),
     ), nullable=False, default={}),
 )

--- a/src/ai/backend/manager/models/scaling_group.py
+++ b/src/ai/backend/manager/models/scaling_group.py
@@ -71,7 +71,7 @@ scaling_groups = sa.Table(
     sa.Column('scheduler_opts', StructuredJSONBColumn(
         t.Dict({
             t.Key('allowed_session_types', default=['interactive', 'batch']):
-                t.List(tx.Enum(SessionTypes)),
+                t.List(tx.Enum(SessionTypes), min_length = 1),
         }).allow_extra('*'),
     ), nullable=False, default={}),
 )

--- a/src/ai/backend/manager/scheduler/predicates.py
+++ b/src/ai/backend/manager/scheduler/predicates.py
@@ -214,7 +214,7 @@ async def check_scaling_group(
     if not sgroups:
         return PredicateResult(
             False,
-            "You don't have any scaling groups allowed to use.",
+            "You do not have any scaling groups allowed to use.",
             permanent=True,
         )
     target_sgroup_names: List[str] = []
@@ -227,7 +227,7 @@ async def check_scaling_group(
         else:
             return PredicateResult(
                 False,
-                f"You don't have access to the scaling group '{preferred_sgroup_name}'.",
+                f"You do not have access to the scaling group '{preferred_sgroup_name}'.",
                 permanent=True,
             )
         allowed_session_types = sgroup['scheduler_opts']['allowed_session_types']

--- a/tests/test_predicates.py
+++ b/tests/test_predicates.py
@@ -1,0 +1,151 @@
+from __future__ import annotations
+
+from unittest import mock
+from unittest.mock import MagicMock
+
+import pytest
+
+from ai.backend.common.types import SessionTypes
+from ai.backend.manager.scheduler.predicates import check_scaling_group
+
+
+@pytest.mark.asyncio
+@mock.patch('ai.backend.manager.scheduler.predicates.execute_with_retry')
+async def test_allowed_session_types_check(mock_query_result):
+    mock_query_result.return_value = [
+        {
+            'name': 'a',
+            'scheduler_opts': {
+                'allowed_session_types': ['batch'],
+            },
+        },
+        {
+            'name': 'b',
+            'scheduler_opts': {
+                'allowed_session_types': ['interactive'],
+            },
+        },
+        {
+            'name': 'c',
+            'scheduler_opts': {
+                'allowed_session_types': ['batch', 'interactive'],
+            },
+        },
+    ]
+    mock_conn = MagicMock()
+    mock_sched_ctx = MagicMock()
+    mock_sess_ctx = MagicMock()
+
+    mock_sess_ctx.session_type = SessionTypes.BATCH
+    mock_sess_ctx.scaling_group = 'a'
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert result.passed
+    assert mock_sess_ctx.target_sgroup_names == ['a']
+
+    mock_sess_ctx.session_type = SessionTypes.BATCH
+    mock_sess_ctx.scaling_group = 'b'
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert not result.passed
+    assert result.message is not None
+    assert "does not accept" in result.message
+    assert mock_sess_ctx.target_sgroup_names == []
+
+    mock_sess_ctx.session_type = SessionTypes.BATCH
+    mock_sess_ctx.scaling_group = 'c'
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert result.passed
+    assert mock_sess_ctx.target_sgroup_names == ['c']
+
+    mock_sess_ctx.session_type = SessionTypes.INTERACTIVE
+    mock_sess_ctx.scaling_group = 'a'
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert not result.passed
+    assert result.message is not None
+    assert "does not accept" in result.message
+    assert mock_sess_ctx.target_sgroup_names == []
+
+    mock_sess_ctx.session_type = SessionTypes.INTERACTIVE
+    mock_sess_ctx.scaling_group = 'b'
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert result.passed
+    assert mock_sess_ctx.target_sgroup_names == ['b']
+
+    mock_sess_ctx.session_type = SessionTypes.INTERACTIVE
+    mock_sess_ctx.scaling_group = 'c'
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert result.passed
+    assert mock_sess_ctx.target_sgroup_names == ['c']
+
+    mock_sess_ctx.session_type = SessionTypes.INTERACTIVE
+    mock_sess_ctx.scaling_group = 'x'
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert not result.passed
+    assert result.message is not None
+    assert "do not have access" in result.message
+    assert mock_sess_ctx.target_sgroup_names == []
+
+    mock_sess_ctx.session_type = SessionTypes.BATCH
+    mock_sess_ctx.scaling_group = None
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert result.passed
+    assert mock_sess_ctx.target_sgroup_names == ['a', 'c']
+
+    mock_sess_ctx.session_type = SessionTypes.INTERACTIVE
+    mock_sess_ctx.scaling_group = None
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert result.passed
+    assert mock_sess_ctx.target_sgroup_names == ['b', 'c']
+
+    mock_query_result.return_value = []
+
+    mock_sess_ctx.session_type = SessionTypes.BATCH
+    mock_sess_ctx.scaling_group = 'x'
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert not result.passed
+    assert result.message is not None
+    assert "do not have any" in result.message
+    assert mock_sess_ctx.target_sgroup_names == []
+
+    mock_sess_ctx.session_type = SessionTypes.INTERACTIVE
+    mock_sess_ctx.scaling_group = 'x'
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert not result.passed
+    assert result.message is not None
+    assert "do not have any" in result.message
+    assert mock_sess_ctx.target_sgroup_names == []
+
+    mock_query_result.return_value = [
+        {
+            'name': 'a',
+            'scheduler_opts': {
+                'allowed_session_types': ['batch'],
+            },
+        },
+    ]
+
+    mock_sess_ctx.session_type = SessionTypes.BATCH
+    mock_sess_ctx.scaling_group = None
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert result.passed
+    assert mock_sess_ctx.target_sgroup_names == ['a']
+
+    mock_sess_ctx.session_type = SessionTypes.INTERACTIVE
+    mock_sess_ctx.scaling_group = None
+    mock_sess_ctx.target_sgroup_names = []
+    result = await check_scaling_group(mock_conn, mock_sched_ctx, mock_sess_ctx)
+    assert not result.passed
+    assert result.message is not None
+    assert "No scaling groups accept" in result.message
+    assert mock_sess_ctx.target_sgroup_names == []


### PR DESCRIPTION
This is a follow-up to lablup/backend.ai#343
Related with: lablup/backend.ai-webui#1190

**prevent allowed session types in empty and fix allowed session types check process handing**

- **Prevent allowed_session_types in empty status  using trafaret.**
Change it not to be empty to solve problem of If the scaling group's allowed_session_types is empty, predicate check fail failure.
![비어있는 경우](https://user-images.githubusercontent.com/18081105/154803980-59df18c7-d7ca-45bb-90ca-6ee48288e55b.png)
![비어있는 경우가 없도록 수정](https://user-images.githubusercontent.com/18081105/154803990-b10d9d41-f112-4ad1-9f5d-1cf8dff51575.png)


- **Fix allowed_session_types check process handing**
Prevent stopping without checking all sgroups during the allowed_session_types check process

