### PR TITLE
fix: Missing replacement of connection with session for ORM query

### DIFF
--- a/changes/553.fix
+++ b/changes/553.fix
@@ -1,1 +1,1 @@
-Change `sqlalchemy.core.Connection` to `sqlalchemy.orm.Session` for querying ORM mapped objects.
+Change `sqlalchemy.engine.Connection` to `sqlalchemy.orm.Session` for querying ORM mapped objects.

--- a/changes/553.fix
+++ b/changes/553.fix
@@ -1,1 +1,1 @@
-Change `sqlalchemy.engine.Connection` to `sqlalchemy.orm.Session` for querying ORM mapped objects.
+Fix a regression introduced in #541 by correcting a missing replacement of `sqlalchemy.engine.Connection` with `sqlalchemy.orm.Session` as `ImageRow` is now an ORM object

--- a/changes/553.fix
+++ b/changes/553.fix
@@ -1,0 +1,1 @@
+Change `sqlalchemy.core.Connection` to `sqlalchemy.orm.Session` for query ORM mapped objects.

--- a/changes/553.fix
+++ b/changes/553.fix
@@ -1,1 +1,1 @@
-Change `sqlalchemy.core.Connection` to `sqlalchemy.orm.Session` for query ORM mapped objects.
+Change `sqlalchemy.core.Connection` to `sqlalchemy.orm.Session` for querying ORM mapped objects.

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -490,7 +490,7 @@ class Image(graphene.ObjectType):
             labels=[
                 KVPair(key=k, value=v)
                 for k, v in row.labels.items()],
-            aliases=row.aliases,
+            aliases=[alias.alias for alias in row.aliases],
             size_bytes=row.size_bytes,
             resource_limits=[
                 ResourceLimit(
@@ -738,12 +738,13 @@ class AliasImage(graphene.Mutation):
         log.info('alias image {0} -> {1} by API request', alias, image_ref)
         ctx: GraphQueryContext = info.context
         try:
-            async with ctx.db.begin() as conn:
-                image_row = await ImageRow.from_image_ref(conn, image_ref, load_aliases=True)
-                if image_row is not None:
-                    await image_row.alias(conn, alias)
+            async with ctx.db.begin_session() as session:
+                try:
+                    image_row = await ImageRow.from_image_ref(session, image_ref, load_aliases=True)
+                except UnknownImageReference:
+                    raise ImageNotFound
                 else:
-                    raise ValueError('Image not found')
+                    image_row.aliases.append(ImageAliasRow(alias=alias, image_id=image_row.id))
         except ValueError as e:
             return AliasImage(ok=False, msg=str(e))
         return AliasImage(ok=True, msg='')

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -490,7 +490,7 @@ class Image(graphene.ObjectType):
             labels=[
                 KVPair(key=k, value=v)
                 for k, v in row.labels.items()],
-            aliases=[alias.alias for alias in row.aliases],
+            aliases=[alias_row.alias for alias_row in row.aliases],
             size_bytes=row.size_bytes,
             resource_limits=[
                 ResourceLimit(


### PR DESCRIPTION
fix: lablup/backend.ai#393
follow-up-for: #541

SQLAlchemy connection: https://docs.sqlalchemy.org/en/14/core/connections.html#sqlalchemy.engine.Connection
SQLAlchemy session: https://docs.sqlalchemy.org/en/14/orm/session_api.html#sqlalchemy.orm.Session

`Connection` is a functionality for DB-API, while `Session` can manage operations for ORM-mapped objects.
`Session` should be used when we want to use ORM functionalities.
