### PR TITLE
fix: A long-standing, critical bug that leaked kernel creation tasks

### DIFF
--- a/changes/558.fix.md
+++ b/changes/558.fix.md
@@ -1,0 +1,1 @@
+Fix a long-standing critical bug that leaked kernel creation coroutine tasks and made some sessions stuck at PREPARING

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1233,10 +1233,10 @@ async def handle_kernel_creation_lifecycle(
         await root_ctx.registry.set_kernel_status(event.kernel_id, KernelStatus.PREPARING, event.reason)
     elif isinstance(event, KernelStartedEvent):
         # post_create_kernel() coroutines are waiting for the creation tracker events to be set.
-        if tracker := root_ctx.registry.kernel_creation_tracker.get(ck_id) and not tracker.done():
+        if (tracker := root_ctx.registry.kernel_creation_tracker.get(ck_id)) and not tracker.done():
             tracker.set_result(None)
     elif isinstance(event, KernelCancelledEvent):
-        if tracker := root_ctx.registry.kernel_creation_tracker.get(ck_id) and not tracker.done():
+        if (tracker := root_ctx.registry.kernel_creation_tracker.get(ck_id)) and not tracker.done():
             tracker.cancel()
 
 

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1233,10 +1233,10 @@ async def handle_kernel_creation_lifecycle(
         await root_ctx.registry.set_kernel_status(event.kernel_id, KernelStatus.PREPARING, event.reason)
     elif isinstance(event, KernelStartedEvent):
         # post_create_kernel() coroutines are waiting for the creation tracker events to be set.
-        if tracker := root_ctx.registry.kernel_creation_tracker.get(ck_id):
+        if tracker := root_ctx.registry.kernel_creation_tracker.get(ck_id) and not tracker.done():
             tracker.set_result(None)
     elif isinstance(event, KernelCancelledEvent):
-        if tracker := root_ctx.registry.kernel_creation_tracker.get(ck_id):
+        if tracker := root_ctx.registry.kernel_creation_tracker.get(ck_id) and not tracker.done():
             tracker.cancel()
 
 

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1425,18 +1425,17 @@ class AgentRegistry:
                 )
                 # Pass the return value of RPC calls to post-processing tasks
                 for created_info in created_infos:
-                    created_kernel_id = KernelId(uuid.UUID(created_info['id']))
-                    self._post_kernel_creation_infos[created_kernel_id].set_result(created_info)
+                    kernel_id = KernelId(uuid.UUID(created_info['id']))
+                    self._post_kernel_creation_infos[kernel_id].set_result(created_info)
                 await asyncio.gather(*post_tasks, return_exceptions=True)
             except Exception as e:
                 # The agent has already cancelled or issued the destruction lifecycle event
                 # for this batch of kernels.
                 for binding in items:
-                    start_future = self.kernel_creation_tracker[binding.kernel.kernel_id]
-                    start_future.cancel()
-                    creation_info_future = self._post_kernel_creation_infos[binding.kernel.kernel_id]
-                    creation_info_future.set_exception(e)
-                await asyncio.sleep(0)
+                    kernel_id = binding.kernel.kernel_id
+                    self.kernel_creation_tracker[kernel_id].cancel()
+                    self._post_kernel_creation_infos[kernel_id].set_exception(e)
+                await asyncio.gather(*post_tasks, return_exceptions=True)
                 raise
 
     async def create_cluster_ssh_keypair(self) -> ClusterSSHKeyPair:


### PR DESCRIPTION
* No matterl the kernel creation in an agent succeeds or fails,
  it should await all post creation tasks to either finalize or handle
  errors.
* This has cuased sessions stuck at "PREPARING" status randomly
  (with varied probability version by version) upon agent-side
  kernel creation failures.
