### PR TITLE
fix: refer vfolder_mounts instead of will-be-deprecated mounts in returning session usage statistics

### DIFF
--- a/changes/561.fix
+++ b/changes/561.fix
@@ -1,1 +1,1 @@
-Fixed a broken session usage statistics API due to recently changed structure of kernel's mount information in DB.
+Fix a regression in the session usage statistics API due to recently changed structure of kernel's mount information in DB

--- a/changes/561.fix
+++ b/changes/561.fix
@@ -1,0 +1,1 @@
+Fixed a broken session usage statistics API due to recently changed structure of kernel's mount information in DB.

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -335,7 +335,7 @@ async def get_container_stats_for_period(request: web.Request, start_date, end_d
         if row['vfolder_mounts']:
             # For >=22.03, return used host directories instead of volume host, which is not so useful.
             nfs = list(set([str(mount.host_path) for mount in row['vfolder_mounts']]))
-        elif row['mounts'] and len(row['mounts']) > 0 and isinstance(row['mounts'][0], list):
+        elif row['mounts'] and isinstance(row['mounts'][0], list):
             # For the kernel records that have legacy contents of `mounts`.
             nfs = list(set([mount[2] for mount in row['mounts']]))
         if row['terminated_at'] is None:

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -332,8 +332,12 @@ async def get_container_stats_for_period(request: web.Request, start_date, end_d
             continue
         last_stat = msgpack.unpackb(raw_stat)
         nfs = None
-        if row['mounts'] is not None:
-            nfs = list(set([mount[1] for mount in row['mounts']]))
+        if row['vfolder_mounts']:
+            # For >=22.03, return used host directory instead of volume host.
+            nfs = list(set([str(mount.host_path) for mount in row['vfolder_mounts']]))
+        elif row['mounts'] and len(row['mounts']) > 0 and isinstance(row['mounts'][0], list):
+            # Access legacy struacuture of `mounts`.
+            nfs = list(set([mount[2] for mount in row['mounts']]))
         if row['terminated_at'] is None:
             used_time = used_days = None
         else:

--- a/src/ai/backend/manager/api/resource.py
+++ b/src/ai/backend/manager/api/resource.py
@@ -333,10 +333,10 @@ async def get_container_stats_for_period(request: web.Request, start_date, end_d
         last_stat = msgpack.unpackb(raw_stat)
         nfs = None
         if row['vfolder_mounts']:
-            # For >=22.03, return used host directory instead of volume host.
+            # For >=22.03, return used host directories instead of volume host, which is not so useful.
             nfs = list(set([str(mount.host_path) for mount in row['vfolder_mounts']]))
         elif row['mounts'] and len(row['mounts']) > 0 and isinstance(row['mounts'][0], list):
-            # Access legacy struacuture of `mounts`.
+            # For the kernel records that have legacy contents of `mounts`.
             nfs = list(set([mount[2] for mount in row['mounts']]))
         if row['terminated_at'] is None:
             used_time = used_days = None


### PR DESCRIPTION
* The structure of the elements of `mounts` is changed from `list` to `str`, so we cannot access it as we did before 22.03.
* To make the contents of NFS value more useful, now it returns the physical host location of vfolders mounted, not just vfolder host, which was not so needed.