### PR TITLE
refactor: final touches on image table

### DIFF
--- a/changes/562.misc
+++ b/changes/562.misc
@@ -1,0 +1,1 @@
+Rewrite `ImageRow.resolve()`'s comment to describe how it works more clearly.

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -20,7 +20,7 @@ import aiotools
 import graphene
 from graphql.execution.executors.asyncio import AsyncioExecutor
 import sqlalchemy as sa
-from sqlalchemy.ext.asyncio import AsyncConnection, AsyncSession
+from sqlalchemy.ext.asyncio import AsyncSession
 from sqlalchemy.orm import (
     relationship,
     selectinload,
@@ -263,7 +263,7 @@ class ImageRow(Base):
     @classmethod
     async def resolve(
         cls,
-        session: AsyncConnection,
+        session: AsyncSession,
         reference_candidates: List[Union[ImageAlias, ImageRef]],
         load_aliases=True,
         strict=False,

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -255,7 +255,6 @@ class ImageRow(Base):
         if len(candidates) == 1 and not strict:
             return candidates[0]
         for row in candidates:
-            log.debug('row: {}', row)
             if row.architecture == ref.architecture:
                 return row
         raise UnknownImageReference

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -268,24 +268,34 @@ class ImageRow(Base):
         load_aliases=True,
         strict=False,
     ) -> ImageRow:
-        """Tries to resolve matching row of image table by iterating through reference_candidates.
-        If type of candidate element is `str`, it'll be considered only as an alias to image.
-        Passing image canonical directly to resolve image data is no longer possible.
-        You need to declare ImageRef object explicitly if you're using string
-        as an image canonical. For example:
-        ```
-        await resolve_image_row(conn, [
-            ImageRef(params['image'], params['image'],
-            params['architecture']),
-        ])
-        ```
-        This kind of pattern is considered as 'good use case',
-        since accepting multiple reference candidates is intended to make
-        user explicitly declare that the code will first try to consider string
-        as an image canonical and try to load image, and changes to alias if it fails.
-        if `strict` is False and image table has only one row
+        """
+        Resolves a matching row in the image table from image references and/or aliases.
+        If candidate element is `ImageRef`, this method will try to resolve image with matching
+        `ImageRef` description. Otherwise, if element is `str`, this will try to follow the alias.
+        If multiple elements are supplied, this method will return the first matched `ImageRow`
+        among those elements.
+        Passing the canonical image reference as string directly to resolve image data
+        is no longer possible. You need to declare ImageRef object explicitly if you're using string
+        as an canonical image references. For example:
+        .. code-block::
+           await ImageRow.resolve(
+               conn,
+               [
+                   ImageRef(
+                       image,
+                       registry,
+                       architecture,
+                   ),
+                   image_alias,
+               ],
+           )
+
+        When *strict_arch* is False and the image table has only one row
         with respect to requested canonical, this function will
-        return that row regardless of actual architecture.
+        return that row regardless of the image architecture.
+
+        When *load_aliases* is True, it tries to resolve the alias chain.
+        Otherwise it finds only the direct image references.
         """
 
         for reference in reference_candidates:


### PR DESCRIPTION
This PR updates `ImageRow.resolve()`'s comment to describe how it works more clearly, fixes some invalidly assigned parameters, and removes logging calls for debug purposes.