### PR TITLE
fix: let admins destroy and get the logs of a session by passing owner's access key in determining the access scope

### DIFF
--- a/changes/564.fix
+++ b/changes/564.fix
@@ -1,0 +1,1 @@
+Make admins query other users' container logs or destroying them again by explicitly passes the `owner_access_key` parameter to the `get_access_key_scope` function.

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -1539,7 +1539,7 @@ async def destroy(request: web.Request, params: Any) -> web.Response:
     session_name = request.match_info['session_name']
     if params['forced'] and request['user']['role'] not in (UserRole.ADMIN, UserRole.SUPERADMIN):
         raise InsufficientPrivilege('You are not allowed to force-terminate')
-    requester_access_key, owner_access_key = await get_access_key_scopes(request)
+    requester_access_key, owner_access_key = await get_access_key_scopes(request, params)
     # domain_name = None
     # if requester_access_key != owner_access_key and \
     #         not request['is_superadmin'] and request['is_admin']:
@@ -1989,7 +1989,7 @@ async def list_files(request: web.Request) -> web.Response:
 async def get_container_logs(request: web.Request, params: Any) -> web.Response:
     root_ctx: RootContext = request.app['_root.context']
     session_name: str = request.match_info['session_name']
-    requester_access_key, owner_access_key = await get_access_key_scopes(request)
+    requester_access_key, owner_access_key = await get_access_key_scopes(request, params)
     log.info('GET_CONTAINER_LOG (ak:{}/{}, s:{})',
              requester_access_key, owner_access_key, session_name)
     resp = {'result': {'logs': ''}}


### PR DESCRIPTION
Until 21.09, the `get_access_key_scope` function [checks the existence of the `owner_access_key` in the request parameter](https://github.com/lablup/backend.ai-manager/blob/57af21944cb7ebdf153ffc867b73c6c5658799a7/src/ai/backend/manager/api/utils.py#L57).

However, in 22.03, this check logic is somehow removed from the `get_access_key_scope`. This change prevented superadmins from querying other users' container logs or destroying them.

Perhaps, the responsibility of providing the parameter `owner_access_key` has moved to callers. So, this PR explicitly passes the `owner_access_key` to the `get_access_key_scope` function from two handlers: `destroy` and `get_container_logs`.