### PR TITLE
feat: implement image metadata related GraphQL mutations

### DIFF
--- a/changes/568.feature
+++ b/changes/568.feature
@@ -1,0 +1,1 @@
+Implement `clean_images` and `modify_image` GraphQL mutation.

--- a/src/ai/backend/manager/models/base.py
+++ b/src/ai/backend/manager/models/base.py
@@ -421,6 +421,17 @@ class KVPair(graphene.ObjectType):
     value = graphene.String()
 
 
+class ResourceLimitInput(graphene.InputObjectType):
+    key = graphene.String()
+    min = graphene.String()
+    max = graphene.String()
+
+
+class KVPairInput(graphene.InputObjectType):
+    key = graphene.String()
+    value = graphene.String()
+
+
 class BigInt(Scalar):
     """
     BigInt is an extension of the regular graphene.Int scalar type
@@ -777,14 +788,17 @@ async def simple_db_mutate_returning_item(
         return result_cls(False, f"unexpected error: {e}", None)
 
 
-def set_if_set(src: object, target: MutableMapping[str, Any], name: str, *, clean_func=None) -> None:
+def set_if_set(
+    src: object, target: MutableMapping[str, Any], name: str, *,
+    clean_func=None, target_key: Optional[str] = None,
+) -> None:
     v = getattr(src, name)
     # NOTE: unset optional fields are passed as null.
     if v is not None:
         if callable(clean_func):
-            target[name] = clean_func(v)
+            target[target_key or name] = clean_func(v)
         else:
-            target[name] = v
+            target[target_key or name] = v
 
 
 async def populate_fixture(

--- a/src/ai/backend/manager/models/gql.py
+++ b/src/ai/backend/manager/models/gql.py
@@ -49,7 +49,9 @@ from .group import (
     PurgeGroup,
 )
 from .image import (
+    ClearImages,
     Image,
+    ModifyImage,
     RescanImages,
     PreloadImage,
     UnloadImage,
@@ -179,9 +181,11 @@ class Mutations(graphene.ObjectType):
     rescan_images = RescanImages.Field()
     preload_image = PreloadImage.Field()
     unload_image = UnloadImage.Field()
+    modify_image = ModifyImage.Field()
     forget_image = ForgetImage.Field()
     alias_image = AliasImage.Field()
     dealias_image = DealiasImage.Field()
+    clear_images = ClearImages.Field()
 
     # super-admin only
     create_keypair_resource_policy = CreateKeyPairResourcePolicy.Field()

--- a/src/ai/backend/manager/models/image.py
+++ b/src/ai/backend/manager/models/image.py
@@ -821,7 +821,6 @@ class ClearImages(graphene.Mutation):
         info: graphene.ResolveInfo,
         registry: str,
     ) -> ClearImages:
-        log.info('clear all images by API request')
         ctx: GraphQueryContext = info.context
         try:
             async with ctx.db.begin_session() as session:
@@ -872,8 +871,6 @@ class ModifyImage(graphene.Mutation):
         architecture: str,
         props: ModifyImageInput,
     ) -> AliasImage:
-        log.info('modify image(ref: {0}) by API request', target)
-
         ctx: GraphQueryContext = info.context
         data: MutableMapping[str, Any] = {}
         set_if_set(props, data, 'name')


### PR DESCRIPTION
This PR implements `clean_images` and `modify_image` mutations and fixes `b"` inserted before every `installed_agents`' element. 
- `clean_images`: removes image (and image aliases, of course) records from designated registry at database. Requires `registry` field. Only images from this registry will be removed.
- `modify_image`: update image metadata records on database. Check `ModifyImageInput` inside `image.py` for supported fields. 