### PR TITLE
fix: remove invalid argument in `image_impl.py`

### DIFF
--- a/changes/569.fix
+++ b/changes/569.fix
@@ -1,0 +1,1 @@
+Fix `inspect_image`, `forget_image` and `alias` commands under `backend.ai mgr etcd` command group failing to run.

--- a/src/ai/backend/manager/cli/image_impl.py
+++ b/src/ai/backend/manager/cli/image_impl.py
@@ -72,7 +72,7 @@ async def inspect_image(cli_ctx, canonical_or_alias, architecture):
                 image_row = await ImageRow.resolve(session, [
                     ImageRef(canonical_or_alias, ['*'], architecture),
                     canonical_or_alias,
-                ], strict=True)
+                ])
                 pprint(await image_row.inspect())
             except UnknownImageReference:
                 log.exception('Image not found.')
@@ -87,7 +87,7 @@ async def forget_image(cli_ctx, canonical_or_alias, architecture):
                 image_row = await ImageRow.resolve(session, [
                     ImageRef(canonical_or_alias, ['*'], architecture),
                     canonical_or_alias,
-                ], strict=True)
+                ])
                 await session.delete(image_row)
             except UnknownImageReference:
                 log.exception('Image not found.')
@@ -131,7 +131,7 @@ async def alias(cli_ctx, alias, target, architecture):
             try:
                 image_row = await ImageRow.resolve(session, [
                     ImageRef(target, ['*'], architecture),
-                ], strict=True)
+                ])
                 await ImageAliasRow.create(session, alias, image_row)
             except UnknownImageReference:
                 log.exception('Image not found.')


### PR DESCRIPTION
This PR removes unused `strict=True` parameters in `image_impl.py`'s method, which results some of `backend.ai image` commands fails to run.