### PR TITLE
Replacible distributed lock backend

### DIFF
--- a/changes/571.feature.md
+++ b/changes/571.feature.md
@@ -1,0 +1,1 @@
+Make the distributed lock backend replacible, choosing one from "filelock" (for single-node deployments only), "pg_advisory" (current impl.), and "etcd" (future)

--- a/config/sample.toml
+++ b/config/sample.toml
@@ -85,7 +85,7 @@ hide-agents = false
 # "pg_advisory" uses PostgreSQL's session-level advisory lock.
 # "redlock" uses Redis-based distributed lock (Redlock) -- currently not supported.
 # "etcd" uses etcd-based distributed lock via etcetra.
-# distributed-lock = "pg_advisory"
+# distributed-lock = "etcd"
 
 # The Docker image name that is used for importing external Docker images.
 # You need to change this if your are at offline environments so that the manager

--- a/config/sample.toml
+++ b/config/sample.toml
@@ -79,6 +79,14 @@ hide-agents = false
 # compatibility issues.
 # event-loop = "asyncio"
 
+# One of: "filelock", "pg_advisory", "redlock", "etcd"
+# Choose the implementation of distributed lock.
+# "filelock" is the simplest one when the manager is deployed on only one node.
+# "pg_advisory" uses PostgreSQL's session-level advisory lock.
+# "redlock" uses Redis-based distributed lock (Redlock) -- currently not supported.
+# "etcd" uses etcd-based distributed lock via etcetra.
+# distributed-lock = "pg_advisory"
+
 # The Docker image name that is used for importing external Docker images.
 # You need to change this if your are at offline environments so that the manager
 # uses an importer image from a private registry.

--- a/setup.cfg
+++ b/setup.cfg
@@ -93,7 +93,7 @@ lint =
     flake8>=4.0.1
     flake8-commas>=2.1
 typecheck =
-    mypy>=0.930
+    mypy>=0.942
     types-click
     types-Jinja2
     types-pkg_resources

--- a/src/ai/backend/manager/api/context.py
+++ b/src/ai/backend/manager/api/context.py
@@ -17,6 +17,7 @@ if TYPE_CHECKING:
     from ..plugin.webapp import WebappPluginContext
     from ..registry import AgentRegistry
     from ..config import LocalConfig, SharedConfig
+    from ..types import DistributedLockFactory
     from .types import CORSOptions
 
 
@@ -28,6 +29,7 @@ class BaseContext:
 class RootContext(BaseContext):
     pidx: int
     db: ExtendedAsyncSAEngine
+    distributed_lock_factory: DistributedLockFactory
     event_dispatcher: EventDispatcher
     event_producer: EventProducer
     redis_live: RedisConnectionInfo

--- a/src/ai/backend/manager/cli/context.py
+++ b/src/ai/backend/manager/cli/context.py
@@ -4,7 +4,6 @@ import atexit
 import contextlib
 import attr
 import os
-from pathlib import Path
 from typing import TYPE_CHECKING, AsyncIterator
 
 from ai.backend.common import redis
@@ -38,8 +37,8 @@ def init_logger(local_config: LocalConfig) -> Logger:
     if 'file' in local_config['logging']['drivers']:
         local_config['logging']['drivers'].remove('file')
     # log_endpoint = f'tcp://127.0.0.1:{find_free_port()}'
-    log_sockpath = Path(f'/tmp/backend.ai/ipc/manager-cli-{os.getpid()}.sock')
-    log_sockpath.parent.mkdir(parents=True, exist_ok=True)
+    ipc_base_path = local_config['manager']['ipc-base-path']
+    log_sockpath = ipc_base_path / f'manager-cli-{os.getpid()}.sock'
     log_endpoint = f'ipc://{log_sockpath}'
 
     def _clean_logger():

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -249,7 +249,7 @@ manager_local_config_iv = t.Dict({
         t.Key('ssl-cert', default=None): t.Null | tx.Path(type='file'),
         t.Key('ssl-privkey', default=None): t.Null | tx.Path(type='file'),
         t.Key('event-loop', default='asyncio'): t.Enum('asyncio', 'uvloop'),
-        t.Key('distributed-lock', default='filelock'):
+        t.Key('distributed-lock', default='etcd'):
             t.Enum('filelock', 'pg_advisory', 'redlock', 'etcd'),
         t.Key('pid-file', default=os.devnull): tx.Path(
             type='file',

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -235,6 +235,8 @@ manager_local_config_iv = t.Dict({
         t.Key('password'): t.String,
     }),
     t.Key('manager'): t.Dict({
+        t.Key('ipc-base-path', default="/tmp/backend.ai/manager/ipc"):
+            tx.Path(type='dir', auto_create=True),
         t.Key('num-proc', default=_max_cpu_count): t.Int[1:_max_cpu_count],
         t.Key('id', default=f"i-{socket.gethostname()}"): t.String,
         t.Key('user', default=None): tx.UserID(default_uid=_file_perm.st_uid),
@@ -247,9 +249,13 @@ manager_local_config_iv = t.Dict({
         t.Key('ssl-cert', default=None): t.Null | tx.Path(type='file'),
         t.Key('ssl-privkey', default=None): t.Null | tx.Path(type='file'),
         t.Key('event-loop', default='asyncio'): t.Enum('asyncio', 'uvloop'),
-        t.Key('pid-file', default=os.devnull): tx.Path(type='file',
-                                                       allow_nonexisting=True,
-                                                       allow_devnull=True),
+        t.Key('distributed-lock', default='filelock'):
+            t.Enum('filelock', 'pg_advisory', 'redlock', 'etcd'),
+        t.Key('pid-file', default=os.devnull): tx.Path(
+            type='file',
+            allow_nonexisting=True,
+            allow_devnull=True,
+        ),
         t.Key('hide-agents', default=False): t.Bool,
         t.Key('importer-image', default='lablup/importer:manylinux2010'): t.String,
         t.Key('max-wsmsg-size', default=16 * (2**20)): t.ToInt,  # default: 16 MiB

--- a/src/ai/backend/manager/defs.py
+++ b/src/ai/backend/manager/defs.py
@@ -39,8 +39,9 @@ REDIS_IMAGE_DB: Final = 3
 REDIS_STREAM_DB: Final = 4
 
 
-# PostgreSQL session-level advisory lock indentifiers
-class AdvisoryLock(enum.IntEnum):
+# The unique identifiers for distributed locks.
+# To be used with PostgreSQL advisory locks, the values are defined as integers.
+class LockID(enum.IntEnum):
     LOCKID_TEST = 42
     LOCKID_SCHEDULE = 91
     LOCKID_PREPARE = 92

--- a/src/ai/backend/manager/idle.py
+++ b/src/ai/backend/manager/idle.py
@@ -49,10 +49,10 @@ from ai.backend.common.logging import BraceStyleAdapter
 from ai.backend.common.types import AccessKey, aobject, SessionTypes
 from ai.backend.common.utils import nmget
 
-from .defs import DEFAULT_ROLE, REDIS_LIVE_DB, REDIS_STAT_DB, AdvisoryLock
+from .defs import DEFAULT_ROLE, REDIS_LIVE_DB, REDIS_STAT_DB, LockID
 from .models import kernels, keypair_resource_policies, keypairs
 from .models.kernel import LIVE_STATUS
-from .pglock import PgAdvisoryLock
+from .types import DistributedLockFactory
 
 if TYPE_CHECKING:
     from .config import SharedConfig
@@ -91,11 +91,13 @@ class BaseIdleChecker(aobject, metaclass=ABCMeta):
         shared_config: SharedConfig,
         event_dispatcher: EventDispatcher,
         event_producer: EventProducer,
+        lock_factory: DistributedLockFactory,
     ) -> None:
         self._db = db
         self._shared_config = shared_config
         self._event_dispatcher = event_dispatcher
         self._event_producer = event_producer
+        self._lock_factory = lock_factory
 
     async def __ainit__(self) -> None:
         self._redis = redis.get_redis_object(
@@ -107,7 +109,7 @@ class BaseIdleChecker(aobject, metaclass=ABCMeta):
         )
         await self.populate_config(raw_config or {})
         self.timer = GlobalTimer(
-            PgAdvisoryLock(self._db, AdvisoryLock.LOCKID_IDLE_CHECK_TIMER),
+            self._lock_factory(LockID.LOCKID_IDLE_CHECK_TIMER),
             self._event_producer,
             lambda: DoIdleCheckEvent(),
             self.check_interval,
@@ -620,6 +622,7 @@ async def create_idle_checkers(
     shared_config: SharedConfig,
     event_dispatcher: EventDispatcher,
     event_producer: EventProducer,
+    lock_factory: DistributedLockFactory,
 ) -> Sequence[BaseIdleChecker]:
     """
     Create an instance of session idleness checker
@@ -638,7 +641,7 @@ async def create_idle_checkers(
             continue
         log.info(f"Initializing idle checker: {checker_name}")
         checker_instance = await checker_cls.new(
-            db, shared_config, event_dispatcher, event_producer,
+            db, shared_config, event_dispatcher, event_producer, lock_factory,
         )
         instances.append(checker_instance)
     return instances

--- a/src/ai/backend/manager/models/utils.py
+++ b/src/ai/backend/manager/models/utils.py
@@ -40,7 +40,7 @@ from ai.backend.common.logging import BraceStyleAdapter
 
 if TYPE_CHECKING:
     from ..config import LocalConfig
-from ..defs import AdvisoryLock
+from ..defs import LockID
 from ..types import Sentinel
 
 log = BraceStyleAdapter(logging.getLogger(__name__))
@@ -112,7 +112,7 @@ class ExtendedAsyncSAEngine(SAEngine):
             yield SASession(bind=conn)
 
     @actxmgr
-    async def advisory_lock(self, lock_id: AdvisoryLock) -> AsyncIterator[None]:
+    async def advisory_lock(self, lock_id: LockID) -> AsyncIterator[None]:
         lock_acquired = False
         # Here we use the session-level advisory lock,
         # which follows the lifetime of underlying DB connection.

--- a/src/ai/backend/manager/pglock.py
+++ b/src/ai/backend/manager/pglock.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import Any
+from typing import Any, AsyncContextManager
 
 from ai.backend.common.distributed import AbstractDistributedLock
 
@@ -10,18 +10,20 @@ from .defs import LockID
 
 class PgAdvisoryLock(AbstractDistributedLock):
 
+    _lock_ctx: AsyncContextManager | None
+
     def __init__(self, db: ExtendedAsyncSAEngine, lock_id: LockID) -> None:
         self.db = db
         self.lock_id = lock_id
-        self._conn = None
+        self._lock_ctx = None
 
     async def __aenter__(self) -> Any:
-        self._conn = self.db.advisory_lock(self.lock_id)
-        await self._conn.__aenter__()
+        self._lock_ctx = self.db.advisory_lock(self.lock_id)
+        await self._lock_ctx.__aenter__()
 
     async def __aexit__(self, *exc_info) -> bool | None:
-        assert self._conn is not None
+        assert self._lock_ctx is not None
         try:
-            return await self._conn.__aexit__(*exc_info)
+            return await self._lock_ctx.__aexit__(*exc_info)
         finally:
-            self._conn = None
+            self._lock_ctx = None

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -74,6 +74,7 @@ from .models.utils import connect_database
 from .plugin.webapp import WebappPluginContext
 from .registry import AgentRegistry
 from .scheduler.dispatcher import SchedulerDispatcher
+from .types import DistributedLockFactory
 
 VALID_VERSIONS: Final = frozenset([
     # 'v1.20160915',  # deprecated
@@ -315,8 +316,13 @@ async def database_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
 
 
 @actxmgr
-async def event_dispatcher_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
+async def distributed_lock_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
+    root_ctx.distributed_lock_factory = init_lock_factory(root_ctx)
+    yield
 
+
+@actxmgr
+async def event_dispatcher_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     root_ctx.event_producer = await EventProducer.new(
         root_ctx.shared_config.data['redis'],
         db=REDIS_STREAM_DB,
@@ -340,6 +346,7 @@ async def idle_checker_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
         root_ctx.shared_config,
         root_ctx.event_dispatcher,
         root_ctx.event_producer,
+        root_ctx.distributed_lock_factory,
     )
     yield
     for instance in root_ctx.idle_checkers:
@@ -394,6 +401,7 @@ async def sched_dispatcher_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     sched_dispatcher = await SchedulerDispatcher.new(
         root_ctx.local_config, root_ctx.shared_config,
         root_ctx.event_dispatcher, root_ctx.event_producer,
+        root_ctx.distributed_lock_factory,
         root_ctx.registry,
     )
     yield
@@ -474,6 +482,31 @@ def init_subapp(pkg_name: str, root_app: web.Application, create_subapp: AppCrea
     _init_subapp(pkg_name, root_app, subapp, global_middlewares)
 
 
+def init_lock_factory(root_ctx: RootContext) -> DistributedLockFactory:
+    ipc_base_path = root_ctx.local_config['manager']['ipc-base-path']
+    manager_id = root_ctx.local_config['manager']['id']
+    lock_backend = root_ctx.local_config['manager']['distributed-lock']
+    log.debug("using {} as the distributed lock backend", lock_backend)
+    match lock_backend:
+        case 'filelock':
+            from ai.backend.common.lock import FileLock
+            return lambda lock_id: FileLock(
+                ipc_base_path / f"{manager_id}.{lock_id}.lock",
+                timeout=0,
+            )
+        case 'pg_advisory':
+            from .pglock import PgAdvisoryLock
+            return lambda lock_id: PgAdvisoryLock(root_ctx.db, lock_id)
+        case 'redlock':
+            raise NotImplementedError("Redlock on aioredis v2 is not supported yet.")
+        case 'etcd':
+            # from ai.backend.common.lock import EtcdLock
+            # return lambda lock_id: EtcdLock(root_ctx.shared_config.etcd, lock_id)
+            raise NotImplementedError("TODO")
+        case other:
+            raise ValueError(f"Invalid lock backend: {other}")
+
+
 def build_root_app(
     pidx: int,
     local_config: LocalConfig, *,
@@ -514,6 +547,7 @@ def build_root_app(
             manager_status_ctx,
             redis_ctx,
             database_ctx,
+            distributed_lock_ctx,
             event_dispatcher_ctx,
             idle_checker_ctx,
             storage_manager_ctx,
@@ -678,8 +712,8 @@ def main(ctx: click.Context, config_path: Path, debug: bool) -> None:
 
     if ctx.invoked_subcommand is None:
         cfg['manager']['pid-file'].write_text(str(os.getpid()))
-        log_sockpath = Path(f'/tmp/backend.ai/ipc/manager-logger-{os.getpid()}.sock')
-        log_sockpath.parent.mkdir(parents=True, exist_ok=True)
+        ipc_base_path = cfg['manager']['ipc-base-path']
+        log_sockpath = ipc_base_path / f'manager-logger-{os.getpid()}.sock'
         log_endpoint = f'ipc://{log_sockpath}'
         try:
             logger = Logger(cfg['logging'], is_master=True, log_endpoint=log_endpoint)

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -500,9 +500,8 @@ def init_lock_factory(root_ctx: RootContext) -> DistributedLockFactory:
         case 'redlock':
             raise NotImplementedError("Redlock on aioredis v2 is not supported yet.")
         case 'etcd':
-            # from ai.backend.common.lock import EtcdLock
-            # return lambda lock_id: EtcdLock(root_ctx.shared_config.etcd, lock_id)
-            raise NotImplementedError("TODO")
+            from ai.backend.common.lock import EtcdLock
+            return lambda lock_id: EtcdLock(str(lock_id), root_ctx.shared_config.etcd)
         case other:
             raise ValueError(f"Invalid lock backend: {other}")
 

--- a/src/ai/backend/manager/types.py
+++ b/src/ai/backend/manager/types.py
@@ -1,12 +1,19 @@
+from __future__ import annotations
+
 import attr
 import enum
 import uuid
 from typing import (
     Protocol,
+    TYPE_CHECKING,
 )
 
 from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.engine.row import Row
+
+if TYPE_CHECKING:
+    from ai.backend.common.distributed import AbstractDistributedLock
+    from .defs import LockID
 
 
 class SessionGetter(Protocol):
@@ -33,3 +40,9 @@ class UserScope:
     group_id: uuid.UUID
     user_uuid: uuid.UUID
     user_role: str
+
+
+class DistributedLockFactory(Protocol):
+
+    def __call__(self, lock_id: LockID) -> AbstractDistributedLock:
+        ...

--- a/tests/test_advisory_lock.py
+++ b/tests/test_advisory_lock.py
@@ -2,7 +2,7 @@ import asyncio
 
 import pytest
 
-from ai.backend.manager.defs import AdvisoryLock
+from ai.backend.manager.defs import LockID
 from ai.backend.manager.models.utils import ExtendedAsyncSAEngine
 
 
@@ -14,7 +14,7 @@ async def test_lock(database_engine: ExtendedAsyncSAEngine) -> None:
 
     async def critical_section(db: ExtendedAsyncSAEngine) -> None:
         nonlocal enter_count
-        async with db.advisory_lock(AdvisoryLock.LOCKID_TEST):
+        async with db.advisory_lock(LockID.LOCKID_TEST):
             enter_count += 1
             await asyncio.sleep(1.0)
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -983,6 +983,7 @@ class DummyEtcd:
 
 @pytest.mark.asyncio
 async def test_manually_assign_agent_available(
+    testing_lock_factory,
     registry_ctx: tuple[AgentRegistry, MagicMock, MagicMock, MagicMock, MagicMock, MagicMock],
     example_agents,
     example_pending_sessions,
@@ -1004,6 +1005,7 @@ async def test_manually_assign_agent_available(
         shared_config=mock_shared_config,
         event_dispatcher=mock_event_dispatcher,
         event_producer=mock_event_producer,
+        lock_factory=testing_lock_factory,
         registry=registry,
     )
 

--- a/tests/test_scheduler.py
+++ b/tests/test_scheduler.py
@@ -983,7 +983,7 @@ class DummyEtcd:
 
 @pytest.mark.asyncio
 async def test_manually_assign_agent_available(
-    testing_lock_factory,
+    file_lock_factory,
     registry_ctx: tuple[AgentRegistry, MagicMock, MagicMock, MagicMock, MagicMock, MagicMock],
     example_agents,
     example_pending_sessions,
@@ -1005,7 +1005,7 @@ async def test_manually_assign_agent_available(
         shared_config=mock_shared_config,
         event_dispatcher=mock_event_dispatcher,
         event_producer=mock_event_producer,
-        lock_factory=testing_lock_factory,
+        lock_factory=file_lock_factory,
         registry=registry,
     )
 


### PR DESCRIPTION
- fix: A bug in PgAdvisoryLock
- ci: Upgrade mypy to the latest version that supports Python 3.10
- feat: Implement replacible distributed lock backend
- feat: Set the default lock backend to "etcd"
