### PR TITLE
fix: rounded down resource not released after kernel creation

### DIFF
--- a/changes/574.fix
+++ b/changes/574.fix
@@ -1,0 +1,1 @@
+Fix `occupied_slots` column on `agents` kernel does not match to actual resource occupied on corresponding agent.

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -1588,7 +1588,7 @@ class AgentRegistry:
 
     async def settle_agent_alloc(
         self, kernel_agent_bindings: Sequence[KernelAgentBinding],
-    ):
+    ) -> None:
         """
         Tries to settle down agent row's occupied_slots with real value. This must be called
         after kernel creation is completed, to prevent fraction of resource dropped by agent scheduler


### PR DESCRIPTION
This PR fixes `occupied_slots` column on `agents` table not matching to actual resource occupied on corresponding agent when fractional resource requested is rounded down to quantum size when creating kernel on agent.