### PR TITLE
fix: remove duplicated logic to obtain redis local time in streaming proxy requests

### DIFF
--- a/changes/576.fix
+++ b/changes/576.fix
@@ -1,0 +1,1 @@
+Remove duplicated logic to obtain redis local time in streaming proxy requests, which caused the depletion of the Redis connection pool.

--- a/src/ai/backend/manager/api/stream.py
+++ b/src/ai/backend/manager/api/stream.py
@@ -467,8 +467,6 @@ async def stream_proxy(defer, request: web.Request, params: Mapping[str, Any]) -
     ''')
 
     async def refresh_cb(kernel_id: str, data: bytes) -> None:
-        now = await redis.execute(redis_live, lambda r: r.time())
-        now = now[0] + (now[1] / (10**6))
         await asyncio.shield(rpc_ptask_group.create_task(
             call_non_bursty(
                 conn_tracker_key,


### PR DESCRIPTION
Getting Redis local time in every streaming proxy request will quickly deplete the Redis connection pool. This was fixed by https://github.com/lablup/backend.ai-manager/pull/526, but reintroduced by https://github.com/lablup/backend.ai-manager/pull/533 by merge mistake.

This PR removes the duplicated logic to suppress the depletion of the Redis connection pool.