### PR TITLE
fix: regression of the logic in getting the container stats per period

### DIFF
--- a/changes/577.fix
+++ b/changes/577.fix
@@ -1,0 +1,1 @@
+Fix regression of the logic in getting the container stats per period.


### PR DESCRIPTION
- List every needed columns in querying kernels information.
- Look up the `last_stat` first and falls back to the `raw_stat` from Redis.
- Change the location of NVIDI GPU's smp and allocated memory stats in the `last_stat`.