### PR TITLE
fix: do not query update where update is empty

### DIFF
--- a/changes/580.fix.md
+++ b/changes/580.fix.md
@@ -1,0 +1,1 @@
+Fix a bogus error by skipping database queries with empty data when syncing kernel statistics

--- a/src/ai/backend/manager/registry.py
+++ b/src/ai/backend/manager/registry.py
@@ -2652,7 +2652,8 @@ class AgentRegistry:
                     })
                 await conn.execute(update_query, params)
 
-        await execute_with_retry(_update)
+        if per_kernel_updates:
+            await execute_with_retry(_update)
 
     async def mark_kernel_terminated(
         self,


### PR DESCRIPTION
<img width="1304" alt="image" src="https://user-images.githubusercontent.com/44239739/164058991-27f7593f-9344-402e-acd7-9a0580be2d08.png">


a method `sync_kernel_stats` in ai.backend.manager.registry.AgentRegistry, `per_kernel_updates` is used to bind update query parameters.
`per_kernel_updates` can be empty but it tries query the update with no binded parameter.