### PR TITLE
fix: changes the default values of session options.

### DIFF
--- a/changes/589.fix
+++ b/changes/589.fix
@@ -1,1 +1,1 @@
-When creating a session, use `get()` to prevent a KeyError from occurring, and change the default values of `callback_url` and `startup_command` to None.
+When creating a session, use `dict.get()` to prevent bogus `KeyError` and change the default values of `callback_url` and `startup_command` to `None` instead of `undefined` (which is for template arguments).

--- a/changes/589.fix
+++ b/changes/589.fix
@@ -1,0 +1,1 @@
+When creating a session, use `get()` to prevent a KeyError from occurring, and change the default values of `callback_url` and `startup_command` to None.

--- a/changes/589.fix
+++ b/changes/589.fix
@@ -1,1 +1,1 @@
-When creating a session, use `dict.get()` to prevent bogus `KeyError` and change the default values of `callback_url` and `startup_command` to `None` instead of `undefined` (which is for template arguments).
+Change the default values of `dependencies`, `callback_url` and `startup_command` to `None` instead of `undefined` (which is for template arguments).

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -489,7 +489,7 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
             _td = str_to_timedelta(params['starts_at'])
             starts_at = datetime.now(tzutc()) + _td
 
-    if params.get('cluster_size') > 1:
+    if params['cluster_size'] > 1:
         log.debug(" -> cluster_mode:{} (replicate)", params['cluster_mode'])
 
     if params.get('dependencies') is None:
@@ -634,7 +634,7 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
         t.Key('maxWaitSeconds', default=0) >> 'max_wait_seconds': t.Int[0:],
         tx.AliasedKey(['starts_at', 'startsAt'], default=None): t.Null | t.String,
         t.Key('reuseIfExists', default=True) >> 'reuse': t.ToBool,
-        t.Key('startupCommand', default=undefined) >> 'startup_command':
+        t.Key('startupCommand', default=None) >> 'startup_command':
             UndefChecker | t.Null | t.String,
         tx.AliasedKey(['bootstrap_script', 'bootstrapScript'], default=undefined):
             UndefChecker | t.Null | t.String,

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -477,12 +477,12 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
         # It's time to create a new session.
         pass
 
-    if params.get('session_type') == SessionTypes.BATCH and not params.get('startup_command'):
+    if params['session_type'] == SessionTypes.BATCH and not params['startup_command']:
         raise InvalidAPIParameters('Batch sessions must have a non-empty startup command.')
-    if params.get('session_type') != SessionTypes.BATCH and params.get('starts_at'):
+    if params['session_type'] != SessionTypes.BATCH and params['starts_at']:
         raise InvalidAPIParameters('Parameter starts_at should be used only for batch sessions')
     starts_at: Union[datetime, None] = None
-    if params.get('starts_at'):
+    if params['starts_at']:
         try:
             starts_at = isoparse(params['starts_at'])
         except ValueError:
@@ -492,10 +492,10 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
     if params['cluster_size'] > 1:
         log.debug(" -> cluster_mode:{} (replicate)", params['cluster_mode'])
 
-    if params.get('dependencies') is None:
+    if params['dependencies'] is None:
         params['dependencies'] = []
 
-    if params.get('callback_url') is None:
+    if params['callback_url'] is None:
         params['callback_url'] = None
 
     session_creation_id = secrets.token_urlsafe(16)
@@ -638,7 +638,7 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
             UndefChecker | t.Null | t.String,
         tx.AliasedKey(['bootstrap_script', 'bootstrapScript'], default=undefined):
             UndefChecker | t.Null | t.String,
-        t.Key('dependencies', default=undefined):
+        t.Key('dependencies', default=None):
             UndefChecker | t.Null | t.List(tx.UUID) | t.List(t.String),
         tx.AliasedKey(['callback_url', 'callbackUrl', 'callbackURL'], default=None):
             UndefChecker | t.Null | tx.URL,

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -495,9 +495,6 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
     if params['dependencies'] is None:
         params['dependencies'] = []
 
-    if params['callback_url'] is None:
-        params['callback_url'] = None
-
     session_creation_id = secrets.token_urlsafe(16)
     start_event = asyncio.Event()
     kernel_id: Optional[KernelId] = None


### PR DESCRIPTION
this PR resolves https://github.com/lablup/backend.ai/issues/420

- `params['VARIABLE_NAME']` -> `params.get('VARIABLE_NAME')`
- Change default value  for `callback_url` and `startup_command` to None in `create_from_template()` like `create_from_params()`.