### PR TITLE
refactor: wrap `UnknownImageReference` as `ObjectNotFound`

### DIFF
--- a/changes/591.feature
+++ b/changes/591.feature
@@ -1,0 +1,1 @@
+Wrap UnknownImageReference as InvalidAPIParameters instead of InternalServerError

--- a/changes/591.feature
+++ b/changes/591.feature
@@ -1,1 +1,1 @@
-Wrap UnknownImageReference as InvalidAPIParameters instead of InternalServerError
+Wrap `UnknownImageReference` as `ObjectNotFound` error instead of `InternalServerError`

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -412,3 +412,8 @@ class KernelRestartFailed(BackendAgentError, web.HTTPInternalServerError):
 class KernelExecutionFailed(BackendAgentError, web.HTTPInternalServerError):
     error_type  = 'https://api.backend.ai/probs/kernel-execution-failed'
     error_title = 'Executing user code in the kernel has failed.'
+
+
+class UnknownImageReferenceError(BackendError, web.HTTPBadRequest):
+    error_type = 'https://api.backend.ai/probs/unknown-image-reference-error'
+    error_title = 'Unknown Image Reference'

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -414,6 +414,5 @@ class KernelExecutionFailed(BackendAgentError, web.HTTPInternalServerError):
     error_title = 'Executing user code in the kernel has failed.'
 
 
-class UnknownImageReferenceError(BackendError, web.HTTPBadRequest):
-    error_type = 'https://api.backend.ai/probs/unknown-image-reference-error'
-    error_title = 'Unknown Image Reference'
+class UnknownImageReferenceError(ObjectNotFound):
+    object_name = 'Unknown Image Reference'

--- a/src/ai/backend/manager/api/exceptions.py
+++ b/src/ai/backend/manager/api/exceptions.py
@@ -415,4 +415,4 @@ class KernelExecutionFailed(BackendAgentError, web.HTTPInternalServerError):
 
 
 class UnknownImageReferenceError(ObjectNotFound):
-    object_name = 'Unknown Image Reference'
+    object_name = 'image reference'

--- a/src/ai/backend/manager/api/session.py
+++ b/src/ai/backend/manager/api/session.py
@@ -128,6 +128,7 @@ from .exceptions import (
     InternalServerError,
     TaskTemplateNotFound,
     StorageProxyError,
+    UnknownImageReferenceError,
 )
 from .auth import auth_required
 from .types import CORSOptions, WebMiddleware
@@ -595,7 +596,7 @@ async def _create(request: web.Request, params: dict[str, Any]) -> web.Response:
         log.exception('GET_OR_CREATE: exception')
         raise
     except UnknownImageReference:
-        raise InvalidAPIParameters(f"Unknown image reference: {params['image']}")
+        raise UnknownImageReferenceError(f"Unknown image reference: {params['image']}")
     except Exception:
         await root_ctx.error_monitor.capture_exception(context={'user': owner_uuid})
         log.exception('GET_OR_CREATE: unexpected error!')
@@ -1101,7 +1102,7 @@ async def create_cluster(request: web.Request, params: dict[str, Any]) -> web.Re
         log.exception('GET_OR_CREATE: exception')
         raise
     except UnknownImageReference:
-        raise InvalidAPIParameters(f"Unknown image reference: {params['image']}")
+        raise UnknownImageReferenceError(f"Unknown image reference: {params['image']}")
     except Exception:
         await root_ctx.error_monitor.capture_exception()
         log.exception('GET_OR_CREATE: unexpected error!')


### PR DESCRIPTION
Apply to wrap UnknownImageReference
1. Define `UnknownImageReferenceError` exception
error_type: 'https://api.backend.ai/probs/unknown-image-reference-error'
error_title: 'Unknown Image Reference'
2. Apply to wrap `UnknownImageReference` as `ObjectNotFound` instead of `InternalServerError`

refs:
- lablup/backend.ai#392
- lablup/backend.ai#378