### PR TITLE
fix: Temporarily rollback the default distributed lock impl.

### DIFF
--- a/changes/592.fix.md
+++ b/changes/592.fix.md
@@ -1,0 +1,1 @@
+Temporarily rollback the default distributed lock implementation to `pg_advisory` from `etcd` until we identify and fix spurious lock timeout issues

--- a/config/sample.toml
+++ b/config/sample.toml
@@ -85,7 +85,7 @@ hide-agents = false
 # "pg_advisory" uses PostgreSQL's session-level advisory lock.
 # "redlock" uses Redis-based distributed lock (Redlock) -- currently not supported.
 # "etcd" uses etcd-based distributed lock via etcetra.
-# distributed-lock = "etcd"
+# distributed-lock = "pg_advisory"
 
 # The Docker image name that is used for importing external Docker images.
 # You need to change this if your are at offline environments so that the manager

--- a/src/ai/backend/manager/config.py
+++ b/src/ai/backend/manager/config.py
@@ -251,7 +251,7 @@ manager_local_config_iv = t.Dict({
         t.Key('ssl-cert', default=None): t.Null | tx.Path(type='file'),
         t.Key('ssl-privkey', default=None): t.Null | tx.Path(type='file'),
         t.Key('event-loop', default='asyncio'): t.Enum('asyncio', 'uvloop'),
-        t.Key('distributed-lock', default='etcd'):
+        t.Key('distributed-lock', default='pg_advisory'):
             t.Enum('filelock', 'pg_advisory', 'redlock', 'etcd'),
         t.Key('pid-file', default=os.devnull): tx.Path(
             type='file',


### PR DESCRIPTION
In our internal testing, etcetra-based distributed lock seems to malfunction when spurious lock timeouts.
Until we find and fix the root cause, temporarily fallback to the prior implementation.
(This is why I've made it as a configurable option!)