### PR TITLE
fix: Update `AbstractDistributedLock` import path

### DIFF
--- a/changes/593.fix
+++ b/changes/593.fix
@@ -1,0 +1,1 @@
+Update `AbstractDistributedLock` import path to keep compatibility with `backend.ai-common`.

--- a/src/ai/backend/manager/pglock.py
+++ b/src/ai/backend/manager/pglock.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any, AsyncContextManager
 
-from ai.backend.common.distributed import AbstractDistributedLock
+from ai.backend.common.lock import AbstractDistributedLock
 
 from .models.utils import ExtendedAsyncSAEngine
 from .defs import LockID

--- a/src/ai/backend/manager/types.py
+++ b/src/ai/backend/manager/types.py
@@ -12,7 +12,7 @@ from sqlalchemy.ext.asyncio import AsyncConnection as SAConnection
 from sqlalchemy.engine.row import Row
 
 if TYPE_CHECKING:
-    from ai.backend.common.distributed import AbstractDistributedLock
+    from ai.backend.common.lock import AbstractDistributedLock
     from .defs import LockID
 
 


### PR DESCRIPTION
Current version raises an exception when running `ai.backend.manager.server`:
```zsh
manager % python -m ai.backend.manager.server --debug

File "/Users/rapsealk/Desktop/git/backend.ai/backend.ai-dev/manager/src/ai/backend/manager/pglock.py", line 5, in <module>
 from ai.backend.common.distributed import AbstractDistributedLock
ImportError: cannot import name 'AbstractDistributedLock' from 'ai.backend.common.distributed' (/Users/rapsealk/Desktop/git/backend.ai/backend.ai-dev/common/src/ai/backend/common/distributed.py)
```

I found that the code to define `AbstractDistributedLock` has moved from `ai.backend.common.distributed` to `ai.backend.common.lock` after commit https://github.com/lablup/backend.ai-common/commit/8aafb0db8d13289f8f12049e8edcb67c3fc60007, but `ai.backend.manager.pglock` is still referencing `ai.backend.common.distributed`.
https://github.com/lablup/backend.ai-manager/blob/332642061df236333e2065644f0c9d73b8b05d99/src/ai/backend/manager/pglock.py#L5