### PR TITLE
fix: Add an explicit check for redis connection

### DIFF
--- a/changes/596.fix
+++ b/changes/596.fix
@@ -1,0 +1,1 @@
+Add explicit connection checks to notify `aioredis.exceptions.ConnectionError` caused by an incorrect server URL or temporary network failures.

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -25,7 +25,6 @@ from typing import (
 
 from aiohttp import web
 import aiohttp_cors
-import aioredis
 import aiotools
 import click
 from pathlib import Path
@@ -302,7 +301,10 @@ async def redis_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     root_ctx.redis_stream = redis.get_redis_object(
         root_ctx.shared_config.data['redis'], db=REDIS_STREAM_DB,
     )
-    for redis_info in [root_ctx.redis_live, root_ctx.redis_stat, root_ctx.redis_image, root_ctx.redis_stream]:
+    for redis_info in [
+        root_ctx.redis_live, root_ctx.redis_stat,
+        root_ctx.redis_image, root_ctx.redis_stream
+    ]:
         await redis.ping_redis_connection(redis_info.client)
     yield
     await root_ctx.redis_stream.close()

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -25,6 +25,7 @@ from typing import (
 
 from aiohttp import web
 import aiohttp_cors
+import aioredis
 import aiotools
 import click
 from pathlib import Path
@@ -291,17 +292,27 @@ async def manager_status_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     yield
 
 
+async def _validate_redis_connection(client: aioredis.client.Redis):
+    try:
+        _ = await client.time()
+    except aioredis.exceptions.ConnectionError as e:
+        raise e
+
+
 @actxmgr
 async def redis_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
-
     root_ctx.redis_live = redis.get_redis_object(root_ctx.shared_config.data['redis'], db=REDIS_LIVE_DB)
+    await _validate_redis_connection(root_ctx.redis_live.client)
     root_ctx.redis_stat = redis.get_redis_object(root_ctx.shared_config.data['redis'], db=REDIS_STAT_DB)
+    await _validate_redis_connection(root_ctx.redis_stat.client)
     root_ctx.redis_image = redis.get_redis_object(
         root_ctx.shared_config.data['redis'], db=REDIS_IMAGE_DB,
     )
+    await _validate_redis_connection(root_ctx.redis_image.client)
     root_ctx.redis_stream = redis.get_redis_object(
         root_ctx.shared_config.data['redis'], db=REDIS_STREAM_DB,
     )
+    await _validate_redis_connection(root_ctx.redis_stream.client)
     yield
     await root_ctx.redis_stream.close()
     await root_ctx.redis_image.close()

--- a/src/ai/backend/manager/server.py
+++ b/src/ai/backend/manager/server.py
@@ -303,7 +303,7 @@ async def redis_ctx(root_ctx: RootContext) -> AsyncIterator[None]:
     )
     for redis_info in [
         root_ctx.redis_live, root_ctx.redis_stat,
-        root_ctx.redis_image, root_ctx.redis_stream
+        root_ctx.redis_image, root_ctx.redis_stream,
     ]:
         await redis.ping_redis_connection(redis_info.client)
     yield


### PR DESCRIPTION
This PR includes a code to check redis connection explicitly.
This will help diagnosis of both permanent failures due to an incorrect server URL and temporary network failures.

Refs
- lablup/backend.ai#424
- lablup/backend.ai-common#139
